### PR TITLE
Bump cookiecutter template to ca268e

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "25c36c49159f9309b55815b6606a8dfb66228858",
+  "commit": "ca268e621fef9b461c8ab1a6cc08b7a76ee31af3",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+run-name: release version ${{ inputs.version }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    branches: ["main"]
+    inputs:
+      version:
+        type: choice
+        description: 'part of the project version to update'
+        options:
+        - major
+        - minor
+        - patch
+        required: true
+
+env:
+  PIP_NO_OPTION: on
+  PIP_NO_CLEAN: on
+  PIP_PREFER_BINARY: on
+
+permissions:
+  contents: write
+
+concurrency:
+  group: "release"
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Cache requirements
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-requirements
+        with:
+          path: ~/.cache/pip
+          key: ${{ env.cache-name }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install requirements
+        run: make setup
+
+      - name: Release new version
+        run: |
+          git config --global user.name 'RKIMetadataExchange'
+          git config --global user.email 'mex@rki.de'
+          pdm release ${{ inputs.version }}

--- a/README.md
+++ b/README.md
@@ -80,10 +80,8 @@ components of the MEx project are open-sourced under the same license as well.
 
 ### creating release
 
-- update version in `pyproject.toml` and `CHANGELOG.md`
-- commit update `git commit --message "..."`
-- create a tag `git tag ...`
-- push `git push --follow-tags`
+- run `pdm release RULE` to release a new version where RULE determines which part of
+  the version to update and is one of `major`, `minor`, `patch`.
 
 ### container workflow
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cruft==2.15.0
-pdm==2.15.2
+mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
+pdm==2.15.3
 pre-commit==3.7.1
 wheel==0.43.0


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/ca268e
