### PR TITLE
Feature/mx 1558 wrap up grippeweb

### DIFF
--- a/mex/grippeweb/transform.py
+++ b/mex/grippeweb/transform.py
@@ -150,6 +150,10 @@ def transform_grippeweb_resource_mappings_to_dict(
             "setValues"
         ]
         rights = resource["rights"][0]["mappingRules"][0]["setValues"]
+        size_of_data_basis = resource["sizeOfDataBasis"][0]["mappingRules"][0][
+            "setValues"
+        ]
+        spatial = resource["spatial"][0]["mappingRules"][0]["setValues"]
         state_of_data_processing = resource["stateOfDataProcessing"][0]["mappingRules"][
             0
         ]["setValues"]
@@ -187,8 +191,10 @@ def transform_grippeweb_resource_mappings_to_dict(
             resourceTypeGeneral=resource_type_general,
             resourceTypeSpecific=resource_type_specific,
             rights=rights,
-            temporal=temporal,
+            sizeOfDataBasis=size_of_data_basis,
+            spatial=spatial,
             stateOfDataProcessing=state_of_data_processing,
+            temporal=temporal,
             theme=theme,
             title=title,
             unitInCharge=unit_in_charge,

--- a/tests/grippeweb/test_transform.py
+++ b/tests/grippeweb/test_transform.py
@@ -117,6 +117,8 @@ def test_transform_grippeweb_resource_mappings_to_dict(
             {"value": "bevölkerungsbasierte Surveillancedaten", "language": "de"}
         ],
         "rights": [{"value": "Verfahren", "language": "de"}],
+        "sizeOfDataBasis": "Meldungen",
+        "spatial": [{"language": "de", "value": "Deutschland"}],
         "stateOfDataProcessing": ["https://mex.rki.de/item/data-processing-state-1"],
         "temporal": "seit 2011",
         "theme": ["https://mex.rki.de/item/theme-35"],


### PR DESCRIPTION
# PR Context
- field `theme` and `resourceTypeGeneral` were fixed through mapping update

# Added
- fields `spatial` and `sizeOfDataBasis` for grippeweb resources

