### PR TITLE
Feature/mx 1612 remove unused asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- remove unused organization_stable_target_id_by_query_sumo asset
+
 ### Fixed
 
 - first test does not receive isolated settings but potentially production settings

--- a/mex/sumo/extract.py
+++ b/mex/sumo/extract.py
@@ -8,8 +8,6 @@ from mex.common.ldap.connector import LDAPConnector
 from mex.common.ldap.models.actor import LDAPActor
 from mex.common.ldap.models.person import LDAPPersonWithQuery
 from mex.common.ldap.transform import analyse_person_string
-from mex.common.wikidata.extract import search_organization_by_label
-from mex.common.wikidata.models.organization import WikidataOrganization
 from mex.sumo.models.cc1_data_model_nokeda import Cc1DataModelNoKeda
 from mex.sumo.models.cc1_data_valuesets import Cc1DataValuesets
 from mex.sumo.models.cc2_aux_mapping import Cc2AuxMapping
@@ -182,24 +180,3 @@ def extract_ldap_contact_points_by_name(
         )
         if len(persons) == 1 and persons[0].objectGUID:
             yield LDAPPersonWithQuery(person=persons[0], query=names)
-
-
-def extract_sumo_organizations(
-    sumo_sumo_resource_nokeda: dict[str, Any],
-) -> dict[str, WikidataOrganization]:
-    """Search and extract sumo organization from wikidata.
-
-    Args:
-        sumo_sumo_resource_nokeda: sumo resource nokeda
-
-    Returns:
-        Dict with organization label and WikidataOrganization
-    """
-    sumo_resource_organizations = {}
-    publisher = sumo_sumo_resource_nokeda["publisher"][0]["mappingRules"][0][
-        "forValues"
-    ][0]
-    for label in [publisher]:
-        if label and (org := search_organization_by_label(label)):
-            sumo_resource_organizations[label] = org
-    return sumo_resource_organizations

--- a/mex/sumo/main.py
+++ b/mex/sumo/main.py
@@ -22,7 +22,6 @@ from mex.common.types import (
     Email,
     MergedContactPointIdentifier,
     MergedOrganizationalUnitIdentifier,
-    MergedOrganizationIdentifier,
 )
 from mex.mapping.extract import extract_mapping_data
 from mex.pipeline import asset, run_job_in_process
@@ -36,7 +35,6 @@ from mex.sumo.extract import (
     extract_cc2_feat_projection,
     extract_ldap_contact_points_by_emails,
     extract_ldap_contact_points_by_name,
-    extract_sumo_organizations,
 )
 from mex.sumo.filter import filter_and_log_cc2_aux_model
 from mex.sumo.models.cc1_data_model_nokeda import Cc1DataModelNoKeda
@@ -56,9 +54,6 @@ from mex.sumo.transform import (
     transform_resource_nokeda_to_mex_resource,
     transform_sumo_access_platform_to_mex_access_platform,
     transform_sumo_activity_to_extracted_activity,
-)
-from mex.wikidata.extract import (
-    get_merged_organization_id_by_query_with_transform_and_load,
 )
 
 
@@ -193,19 +188,6 @@ def extracted_cc2_aux_model_sumo(
 def extracted_cc2_feat_projection() -> list[Cc2FeatProjection]:
     """Extract Cc2 features from SUMO data."""
     return list(extract_cc2_feat_projection())
-
-
-@asset(group_name="sumo")
-def organization_stable_target_id_by_query_sumo(
-    extracted_resources_nokeda_sumo: dict[str, Any],
-    extracted_primary_source_wikidata: ExtractedPrimarySource,
-) -> dict[str, MergedOrganizationIdentifier]:
-    """Extract and load SUMO organizations and return them by stable target ids."""
-    sumo_organizations = extract_sumo_organizations(extracted_resources_nokeda_sumo)
-
-    return get_merged_organization_id_by_query_with_transform_and_load(
-        sumo_organizations, extracted_primary_source_wikidata
-    )
 
 
 @asset(group_name="sumo")

--- a/tests/sumo/test_extract.py
+++ b/tests/sumo/test_extract.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 import pytest
 
-from mex.common.wikidata.models.organization import WikidataOrganization
 from mex.sumo.extract import (
     extract_cc1_data_model_nokeda,
     extract_cc1_data_valuesets,
@@ -14,7 +13,6 @@ from mex.sumo.extract import (
     extract_cc2_feat_projection,
     extract_ldap_contact_points_by_emails,
     extract_ldap_contact_points_by_name,
-    extract_sumo_organizations,
 )
 from mex.sumo.models.cc1_data_model_nokeda import Cc1DataModelNoKeda
 from mex.sumo.models.cc1_data_valuesets import Cc1DataValuesets
@@ -135,16 +133,3 @@ def test_extract_ldap_contact_points_by_name(
 
     extracted = list(extract_ldap_contact_points_by_name(sumo_access_platform))
     assert extracted[0].model_dump() == expected
-
-
-@pytest.mark.usefixtures(
-    "mocked_wikidata",
-)
-def test_extract_sumo_organizations(
-    sumo_resources_nokeda: dict[str, Any],
-    wikidata_organization: WikidataOrganization,
-) -> None:
-    organizations = extract_sumo_organizations(sumo_resources_nokeda)
-    assert organizations == {
-        "Robert Koch-Institut": wikidata_organization,
-    }


### PR DESCRIPTION
# PR Context

asset organization_stable_target_id_by_query_sumo is not needed as the organization "Robert-Koch Institut" is provided by a dedicated asset.

# Removed
- remove unused organization_stable_target_id_by_query_sumo asset


