### PR TITLE
Bump cookiecutter template to cf7f28

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "39db8b85e6bbde62ab72318329d9410f14187dab",
+  "commit": "cf7f28ed2a2abbeb6b7eb2319e5c894d7020d675",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ For further details, please consult our
 [FAIR data principles](https://www.go-fair.org/fair-principles/) – guidelines to make
 data Findable, Accessible, Interoperable and Reusable.
 
+**Contact** \
+For more information, please feel free to email us at [mex@rki.de](mailto:mex@rki.de).
+
+### Publisher of this document
+**Robert Koch-Institut** \
+Nordufer 20 \
+13353 Berlin \
+Germany
+
 ## package
 
 The `mex-extractors` package implements a variety of ETL pipelines to **extract**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,11 @@ markers = "integration: mark a test as integration test"
 
 [tool.ruff]
 fix = true
+line-length = 88
 show-fixes = true
+
+[tool.ruff.format]
+docstring-code-format = true
 
 [tool.ruff.lint]
 ignore = [


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/cf7f28

# Conflicts

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -9,15 +9,14 @@ urls = { Repository = "https://github.com/robert-koch-institut/mex-extractors" }
 requires-python = "<3.13,>=3.11"
 dependencies = []
 optional-dependencies.dev = [
-    "black==24.4.2",
     "ipdb==0.13.13",
-    "mypy==1.10.0",
+    "mypy==1.11.0",
     "pytest-cov==5.0.0",
     "pytest-random-order==1.1.1",
     "pytest-xdist==3.6.1",
-    "pytest==8.2.2",
-    "ruff==0.4.9",
-    "sphinx==7.3.7",
+    "pytest==8.3.1",
+    "ruff==0.5.4",
+    "sphinx==7.4.0",
 ]
 
 [project.scripts]
@@ -126,5 +129,5 @@ known-first-party = ["mex", "tests"]
 convention = "google"
 
 [build-system]
-requires = ["pdm-backend==2.3.0"]
+requires = ["pdm-backend==2.3.3"]
 build-backend = "pdm.backend"
```

```diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -88,7 +88,7 @@ jobs:
     needs: release
     steps:
       - name: Build, tag and push docker image to ghcr
-        uses: GlueOps/github-actions-build-push-containers@v0.4.2
+        uses: GlueOps/github-actions-build-push-containers@v0.4.3
         with:
           tags: "${{ github.sha }},${{ needs.release.outputs.tag }},latest"
 
```

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.1.12
+        uses: renovatebot/github-action@v40.2.2
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-extractors"
```

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-pdm==2.15.4
+pdm==2.17.1
 pre-commit==3.7.1
 wheel==0.43.0
```

```diff a/.pre-commit-config.yaml b/.pre-commit-config.yaml	(rejected hunks)
@@ -2,15 +2,12 @@ fail_fast: false
 default_language_version:
   python: python3.11
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.9
+    rev: v0.5.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
@@ -28,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.15.4
+    rev: 2.17.1
     hooks:
       - id: pdm-lock-check
         name: pdm
```
