### PR TITLE
comment out broken entity lookups

### DIFF
--- a/mex/ff_projects/transform.py
+++ b/mex/ff_projects/transform.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 from mex.common.exceptions import MExError
 from mex.common.models import ExtractedActivity, ExtractedPrimarySource
@@ -10,37 +11,7 @@ from mex.common.types import (
 )
 from mex.ff_projects.models.source import FFProjectsSource
 
-# RKI_AZ_TYPES = {
-#     "1360": [
-#         ActivityType["CONTRACT_RESEARCH"],
-#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-#     ],
-#     "1361": [
-#         ActivityType["CONTRACT_RESEARCH"],
-#         ActivityType["INTERNATIONAL_PROJECT"],
-#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-#     ],
-#     "1363": [
-#         ActivityType["INTERNATIONAL_PROJECT"],
-#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-#     ],
-#     "1364": [
-#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-#     ],
-#     "1365": [
-#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-#     ],
-#     "1367": [
-#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-#     ],
-#     "1368": [
-#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-#     ],
-#     "1362": [
-#         ActivityType["SPECIAL_RESEARCH_PROJECT"],
-#     ],
-#     "1369": [ActivityType["OTHER"]],
-# }
+RKI_AZ_TYPES: dict[str, Any] = {}
 
 
 def get_rki_az_types(rki_azs: str) -> list[ActivityType]:

--- a/mex/ff_projects/transform.py
+++ b/mex/ff_projects/transform.py
@@ -10,37 +10,37 @@ from mex.common.types import (
 )
 from mex.ff_projects.models.source import FFProjectsSource
 
-RKI_AZ_TYPES = {
-    "1360": [
-        ActivityType["CONTRACT_RESEARCH"],
-        ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-    ],
-    "1361": [
-        ActivityType["CONTRACT_RESEARCH"],
-        ActivityType["INTERNATIONAL_PROJECT"],
-        ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-    ],
-    "1363": [
-        ActivityType["INTERNATIONAL_PROJECT"],
-        ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-    ],
-    "1364": [
-        ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-    ],
-    "1365": [
-        ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-    ],
-    "1367": [
-        ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-    ],
-    "1368": [
-        ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-    ],
-    "1362": [
-        ActivityType["SPECIAL_RESEARCH_PROJECT"],
-    ],
-    "1369": [ActivityType["OTHER"]],
-}
+# RKI_AZ_TYPES = {
+#     "1360": [
+#         ActivityType["CONTRACT_RESEARCH"],
+#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
+#     ],
+#     "1361": [
+#         ActivityType["CONTRACT_RESEARCH"],
+#         ActivityType["INTERNATIONAL_PROJECT"],
+#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
+#     ],
+#     "1363": [
+#         ActivityType["INTERNATIONAL_PROJECT"],
+#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
+#     ],
+#     "1364": [
+#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
+#     ],
+#     "1365": [
+#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
+#     ],
+#     "1367": [
+#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
+#     ],
+#     "1368": [
+#         ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
+#     ],
+#     "1362": [
+#         ActivityType["SPECIAL_RESEARCH_PROJECT"],
+#     ],
+#     "1369": [ActivityType["OTHER"]],
+# }
 
 
 def get_rki_az_types(rki_azs: str) -> list[ActivityType]:

--- a/mex/international_projects/transform.py
+++ b/mex/international_projects/transform.py
@@ -7,36 +7,8 @@ from mex.common.types import (
     MergedOrganizationalUnitIdentifier,
     MergedOrganizationIdentifier,
     MergedPersonIdentifier,
-    Theme,
 )
 from mex.international_projects.models.source import InternationalProjectsSource
-
-# THEME_BY_ACTIVITY_OR_TOPIC = {
-#     "Other": Theme["PUBLIC_HEALTH"],
-#     "Crisis management": Theme["PUBLIC_HEALTH"],
-#     "Capacity building including trainings": Theme["PUBLIC_HEALTH"],
-#     "Conducting research": Theme["RESEARCH"],
-#     "Supporting global governance structures and processes": Theme["PUBLIC_HEALTH"],
-#     "Public health systems": Theme["PUBLIC_HEALTH"],
-#     "Non-communicable diseases": Theme["NON_COMMUNICABLE_DISEASES"],
-#     "Laboratory diagnostics": Theme["LABORATORY"],
-#     "One Health": Theme["ONE_HEALTH"],
-#     "Surveillance (infectious diseases)": Theme["PUBLIC_HEALTH"],
-#     "Vaccines/vaccinations": Theme["PUBLIC_HEALTH"],
-# }
-# ACTIVITY_TYPES_BY_FUNDING_TYPE = defaultdict(
-#     lambda: [ActivityType["INTERNATIONAL_PROJECT"]],
-#     {
-#         "Third party funded": [
-#             ActivityType["INTERNATIONAL_PROJECT"],
-#             ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-#         ],
-#         "RKI funded": [
-#             ActivityType["INTERNATIONAL_PROJECT"],
-#             ActivityType["RKI_INTERNAL_PROJECT"],
-#         ],
-#     },
-# )
 
 
 def transform_international_projects_source_to_extracted_activity(
@@ -104,7 +76,7 @@ def transform_international_projects_source_to_extracted_activity(
 
     return ExtractedActivity(
         title=source.full_project_name,
-        activityType=ACTIVITY_TYPES_BY_FUNDING_TYPE.get(source.funding_type),
+        activityType={},
         alternativeTitle=source.project_abbreviation,
         contact=[*project_leads, project_lead_rki_unit],
         involvedPerson=project_leads,
@@ -119,9 +91,7 @@ def transform_international_projects_source_to_extracted_activity(
         hadPrimarySource=extracted_primary_source.stableTargetId,
         fundingProgram=source.funding_program if source.funding_program else [],
         shortName=source.project_abbreviation,
-        theme=get_theme_for_activity_or_topic(
-            source.activity1, source.activity2, source.topic1, source.topic2
-        ),
+        theme=[],
         website=(
             []
             if source.website in ("", "does not exist yet")
@@ -170,37 +140,3 @@ def transform_international_projects_sources_to_extracted_activities(
             partner_organizations_stable_target_id_by_query,
         ):
             yield activity
-
-
-def get_theme_for_activity_or_topic(
-    activity1: str | None, activity2: str | None, topic1: str | None, topic2: str | None
-) -> list[Theme]:
-    """Get theme identifier for activities and topics.
-
-    Args:
-        activity1: activity 1
-        activity2: activity 1
-        topic1: topic 1
-        topic2: topic 2
-
-    Returns:
-        Sorted list of Theme
-    """
-    theme = set()
-
-    if not activity1 and activity2 and topic1 and topic2:
-        return [THEME_BY_ACTIVITY_OR_TOPIC["Other"]]
-    if activity1:
-        if a1 := THEME_BY_ACTIVITY_OR_TOPIC.get(activity1):
-            theme.add(a1)
-    if activity2:
-        if a2 := THEME_BY_ACTIVITY_OR_TOPIC.get(activity2):
-            theme.add(a2)
-    if topic1:
-        if t1 := THEME_BY_ACTIVITY_OR_TOPIC.get(topic1):
-            theme.add(t1)
-    if topic2:
-        if t2 := THEME_BY_ACTIVITY_OR_TOPIC.get(topic2):
-            theme.add(t2)
-
-    return sorted(list(theme), key=lambda x: x.name)

--- a/mex/international_projects/transform.py
+++ b/mex/international_projects/transform.py
@@ -1,10 +1,8 @@
-from collections import defaultdict
 from collections.abc import Generator, Hashable, Iterable
 
 from mex.common.logging import watch
 from mex.common.models import ExtractedActivity, ExtractedPrimarySource
 from mex.common.types import (
-    ActivityType,
     Link,
     MergedOrganizationalUnitIdentifier,
     MergedOrganizationIdentifier,
@@ -13,32 +11,32 @@ from mex.common.types import (
 )
 from mex.international_projects.models.source import InternationalProjectsSource
 
-THEME_BY_ACTIVITY_OR_TOPIC = {
-    "Other": Theme["PUBLIC_HEALTH"],
-    "Crisis management": Theme["PUBLIC_HEALTH"],
-    "Capacity building including trainings": Theme["PUBLIC_HEALTH"],
-    "Conducting research": Theme["RESEARCH"],
-    "Supporting global governance structures and processes": Theme["PUBLIC_HEALTH"],
-    "Public health systems": Theme["PUBLIC_HEALTH"],
-    "Non-communicable diseases": Theme["NON_COMMUNICABLE_DISEASES"],
-    "Laboratory diagnostics": Theme["LABORATORY"],
-    "One Health": Theme["ONE_HEALTH"],
-    "Surveillance (infectious diseases)": Theme["PUBLIC_HEALTH"],
-    "Vaccines/vaccinations": Theme["PUBLIC_HEALTH"],
-}
-ACTIVITY_TYPES_BY_FUNDING_TYPE = defaultdict(
-    lambda: [ActivityType["INTERNATIONAL_PROJECT"]],
-    {
-        "Third party funded": [
-            ActivityType["INTERNATIONAL_PROJECT"],
-            ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
-        ],
-        "RKI funded": [
-            ActivityType["INTERNATIONAL_PROJECT"],
-            ActivityType["RKI_INTERNAL_PROJECT"],
-        ],
-    },
-)
+# THEME_BY_ACTIVITY_OR_TOPIC = {
+#     "Other": Theme["PUBLIC_HEALTH"],
+#     "Crisis management": Theme["PUBLIC_HEALTH"],
+#     "Capacity building including trainings": Theme["PUBLIC_HEALTH"],
+#     "Conducting research": Theme["RESEARCH"],
+#     "Supporting global governance structures and processes": Theme["PUBLIC_HEALTH"],
+#     "Public health systems": Theme["PUBLIC_HEALTH"],
+#     "Non-communicable diseases": Theme["NON_COMMUNICABLE_DISEASES"],
+#     "Laboratory diagnostics": Theme["LABORATORY"],
+#     "One Health": Theme["ONE_HEALTH"],
+#     "Surveillance (infectious diseases)": Theme["PUBLIC_HEALTH"],
+#     "Vaccines/vaccinations": Theme["PUBLIC_HEALTH"],
+# }
+# ACTIVITY_TYPES_BY_FUNDING_TYPE = defaultdict(
+#     lambda: [ActivityType["INTERNATIONAL_PROJECT"]],
+#     {
+#         "Third party funded": [
+#             ActivityType["INTERNATIONAL_PROJECT"],
+#             ActivityType["THIRD_PARTY_FUNDED_PROJECT"],
+#         ],
+#         "RKI funded": [
+#             ActivityType["INTERNATIONAL_PROJECT"],
+#             ActivityType["RKI_INTERNAL_PROJECT"],
+#         ],
+#     },
+# )
 
 
 def transform_international_projects_source_to_extracted_activity(

--- a/tests/international_projects/test_transform.py
+++ b/tests/international_projects/test_transform.py
@@ -1,4 +1,3 @@
-import pytest
 from pytz import timezone
 
 from mex.common.models import ExtractedPrimarySource
@@ -6,12 +5,10 @@ from mex.common.testing import Joker
 from mex.common.types import (
     Identifier,
     TextLanguage,
-    Theme,
     YearMonthDay,
 )
 from mex.international_projects.extract import extract_international_projects_sources
 from mex.international_projects.transform import (
-    get_theme_for_activity_or_topic,
     transform_international_projects_sources_to_extracted_activities,
 )
 
@@ -75,44 +72,3 @@ def test_transform_international_projects_source_to_mex_source(
         extracted_activities[0].model_dump(exclude_none=True, exclude_defaults=True)
         == expected
     )
-
-
-@pytest.mark.parametrize(
-    ("activity1", "activity2", "topic1", "topic2", "expected_themes"),
-    [
-        ("Crisis management", "", "", "", [Theme["PUBLIC_HEALTH"]]),
-        ("", "", "", "Other", [Theme["PUBLIC_HEALTH"]]),
-        (
-            "Capacity building including trainings",
-            "",
-            "Crisis management",
-            "",
-            [Theme["PUBLIC_HEALTH"]],
-        ),
-        (
-            "Non-communicable diseases",
-            "",
-            "Crisis management",
-            "",
-            [Theme["PUBLIC_HEALTH"], Theme["NON_COMMUNICABLE_DISEASES"]],
-        ),
-        (
-            "",
-            "Laboratory diagnostics",
-            "",
-            "Non-communicable diseases",
-            [Theme["NON_COMMUNICABLE_DISEASES"], Theme["LABORATORY"]],
-        ),
-    ],
-)
-def test_get_theme_for_activity_or_topic(
-    activity1: str,
-    activity2: str,
-    topic1: str,
-    topic2: str,
-    expected_themes: list[Theme],
-) -> None:
-    theme = get_theme_for_activity_or_topic(activity1, activity2, topic1, topic2)
-
-    assert len(theme) == len(expected_themes)
-    assert theme == sorted(list(expected_themes), key=lambda x: x.name)


### PR DESCRIPTION
# PR Context
- The entity lookups in ff-projects and international projects are broken and throw an error already at import for all extractors. Commenting them out helps addressing individual extractors one by one



# Removed
- broken entity lookups


