### PR TITLE
Bump cookiecutter template to 916798

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "bae86448088992cdbd3acde751ad7aa19a79d71b",
+  "commit": "9167981a2eb9889a68c72a5b3cbdb11d5702c4b8",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",

--- a/.dockerignore
+++ b/.dockerignore
@@ -47,8 +47,9 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+test*.jpeg
+test*.png
 *.cover
-*.jpeg
 *.py,cover
 .hypothesis/
 .pytest_cache/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,14 +114,14 @@ jobs:
         run: |
           pdm export --self --output locked-requirements.txt --no-hashes --without dev
 
-      - name: 'Login to GitHub Container Registry'
+      - name: Login to container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
-      - name: 'Build Inventory Image'
+      - name: Build, tag and push docker image
         run: |
           docker build . \
           --tag ghcr.io/robert-koch-institut/mex-extractors:latest \

--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,9 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+test*.jpeg
+test*.png
 *.cover
-*.jpeg
 *.py,cover
 .hypothesis/
 .pytest_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.4
+    rev: v0.6.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.17.1
+    rev: 2.18.2
     hooks:
       - id: pdm-lock-check
         name: pdm


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/916798

# Conflicts

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-pdm==2.18.1
+pdm==2.19.1
 pre-commit==3.8.0
 wheel==0.44.0
```

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.2.7
+        uses: renovatebot/github-action@v40.3.1
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-extractors"
```

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -6,17 +6,17 @@ authors = [{ name = "MEx Team", email = "mex@rki.de" }]
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE" }
 urls = { Repository = "https://github.com/robert-koch-institut/mex-extractors" }
-requires-python = "<3.13,>=3.11"
+requires-python = ">=3.11,<3.13"
 dependencies = []
 optional-dependencies.dev = [
     "ipdb>=0.13.13,<1",
-    "mypy>=1.11.0,<2",
+    "mypy>=1.11.2,<2",
     "pytest-cov>=5.0.0,<6",
     "pytest-random-order>=1.1.1,<2",
     "pytest-xdist>=3.6.1,<4",
-    "pytest>=8.3.1,<9",
-    "ruff>=0.5.4,<1",
-    "sphinx>=7.4.5,<8",
+    "pytest>=8.3.3,<9",
+    "ruff>=0.6.5,<1",
+    "sphinx>=8.0.2,<9",
 ]
 
 [project.scripts]
@@ -129,5 +129,5 @@ known-first-party = ["mex", "tests"]
 convention = "google"
 
 [build-system]
-requires = ["pdm-backend==2.3.3"]
+requires = ["pdm-backend==2.4.1"]
 build-backend = "pdm.backend"
```
