### PR TITLE
feature/mx-1711 prepare artificial data extractor for roundtrip workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Changes
+- increase minimum valid artificial data count to two times the number of entity types
 
 ### Deprecated
 
 ### Removed
+
+- remove `matched` setting for the artificial extractor, since that was not implemented
+- stop configuring entity-type weights for artificial data, since that broke determinism
+- removed unused `-c` alias for the count setting of the artificial extractor
 - deprecated mapping commit hashes in README
 
 ### Fixed
@@ -30,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING: refactor package structure from `mex.foo` to `mex.extractors.foo`
 - BREAKING: Mapping extractors now returns Mapping models instead of nested dictionaries
-- model v3 update: artifical, international-projects, seqrepo, synopse, blueant, sumo,
+- model v3 update: artificial, international-projects, seqrepo, synopse, blueant, sumo,
   biospecimen, odk, datscha-web, confluence-vvt, grippeweb, voxco, ifsg
 
 ### Fixed

--- a/mex/extractors/artificial/identity.py
+++ b/mex/extractors/artificial/identity.py
@@ -1,13 +1,12 @@
 from binascii import crc32
-from collections.abc import Sequence
 
 from faker import Faker
 
 from mex.common.identity import Identity, get_provider
 from mex.common.identity.memory import MemoryIdentityProvider
 from mex.common.models import (
+    EXTRACTED_MODEL_CLASSES,
     MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
-    ExtractedData,
 )
 from mex.common.types import MergedPrimarySourceIdentifier
 from mex.extractors.settings import Settings
@@ -24,7 +23,7 @@ def restore_identities(identity_map: IdentityMap) -> None:
     Args:
         identity_map: Identity map that needs to be loaded back into the provider
     """
-    # TODO: Resolve this ugliness by letting the MemoryIdentityProvider cache its
+    # TODO(ND): Resolve this ugliness by letting the MemoryIdentityProvider cache its
     # identity map in the dagster io manager.
     identity_provider = get_provider()
     if isinstance(identity_provider, MemoryIdentityProvider):
@@ -39,9 +38,7 @@ def _get_offset_int(cls: type) -> int:
     return crc32(cls.__name__.encode())
 
 
-def _create_numeric_ids(
-    faker: Faker, weights: dict[type[ExtractedData], int]
-) -> dict[str, Sequence[int]]:
+def _create_numeric_ids(faker: Faker) -> dict[str, list[int]]:
     """Create a mapping from entity type to a list of numeric ids.
 
     These numeric ids can be used as seeds for the identity of artificial items.
@@ -50,40 +47,32 @@ def _create_numeric_ids(
 
     Args:
         faker: Instance of faker
-        weights: Mapping from extracted data classes to an integer weight. The weights
-                 control how many items per class are created, but the weights are
-                 normalized to keep the total below `Settings.artificial.count`.
 
     Returns:
         Dict with entity types and lists of numeric ids
     """
     settings = Settings.get()
-    # compile a list of model classes (each model class can appear multiple times)
-    # by adding some models more often than others, we can influence the likelihood
-    # of `random_choices` picking that class from the list of models
-    weighted_model_class_list = [
-        model for model, weight in weights.items() for _ in range(weight)
-    ]
-    # pick a random selection of model classes from the weighted model class list
+    # pick a random selection of model classes from list of extracted model classes
     choices = list(
-        faker.random_choices(weighted_model_class_list, settings.artificial.count)
+        faker.random_choices(
+            EXTRACTED_MODEL_CLASSES,
+            length=settings.artificial.count - len(EXTRACTED_MODEL_CLASSES),
+        )
     )
     # count the picks, but use at least 2 so we can fulfill required references
-    counts = {model: max(2, choices.count(model)) for model in weights}
+    counts = {model: max(2, choices.count(model)) for model in EXTRACTED_MODEL_CLASSES}
     # build a static offset integer per class to spread out the id ranges
-    offsets = {model: _get_offset_int(model) for model in weights}
+    offsets = {model: _get_offset_int(model) for model in EXTRACTED_MODEL_CLASSES}
     # calculate numeric ids per model in the calculated quantities
     return {
-        model.__name__.removeprefix("Extracted"): range(
-            offsets[model], offsets[model] + counts[model]
+        model.__name__.removeprefix("Extracted"): list(
+            range(offsets[model], offsets[model] + counts[model])
         )
-        for model in weights
+        for model in EXTRACTED_MODEL_CLASSES
     }
 
 
-def create_identities(
-    faker: Faker, weights: dict[type[ExtractedData], int]
-) -> IdentityMap:
+def create_identities(faker: Faker) -> IdentityMap:
     """Create the identities of the to-be-faked models.
 
     We do this **before** actually creating the models, because we need to be able
@@ -91,15 +80,12 @@ def create_identities(
 
     Args:
         faker: Instance of faker
-        weights: Mapping from extracted data classes to an integer weight. The weights
-                control how many items per class are created, but the weights are
-                normalized to keep the total below `Settings.artificial.count`.
 
     Returns:
         Dict with entity types and lists of Identities
     """
     # create the numeric id dictionary
-    numeric_ids = _create_numeric_ids(faker, weights)
+    numeric_ids = _create_numeric_ids(faker)
     # store a map of identities by entity type
     identity_map: IdentityMap = {entity_type: [] for entity_type in numeric_ids}
     # primary sources need identities first
@@ -116,8 +102,6 @@ def create_identities(
             else:
                 # the first primary source is extracted from this placeholder ID
                 primary_source_id = MEX_PRIMARY_SOURCE_STABLE_TARGET_ID
-            # TODO: allow for a configured percentage of items to have the same
-            #       stable target ID (using `Settings.artificial.matched`)
             identity = identity_provider.assign(
                 primary_source_id, f"{entity_type}-{numeric_id}"
             )

--- a/mex/extractors/artificial/main.py
+++ b/mex/extractors/artificial/main.py
@@ -1,22 +1,7 @@
 from faker import Faker
 
 from mex.common.cli import entrypoint
-from mex.common.models import (
-    EXTRACTED_MODEL_CLASSES,
-    ExtractedAccessPlatform,
-    ExtractedActivity,
-    ExtractedBibliographicResource,
-    ExtractedConsent,
-    ExtractedContactPoint,
-    ExtractedDistribution,
-    ExtractedOrganization,
-    ExtractedOrganizationalUnit,
-    ExtractedPerson,
-    ExtractedPrimarySource,
-    ExtractedResource,
-    ExtractedVariable,
-    ExtractedVariableGroup,
-)
+from mex.common.models import EXTRACTED_MODEL_CLASSES
 from mex.extractors.artificial.identity import (
     IdentityMap,
     create_identities,
@@ -46,25 +31,8 @@ def faker() -> Faker:
 
 @asset(group_name="artificial")
 def identities(faker: Faker) -> IdentityMap:
-    """Create a map of identities for each of the weighted model classes."""
-    return create_identities(
-        faker,
-        {
-            ExtractedPrimarySource: 10,
-            ExtractedAccessPlatform: 10,
-            ExtractedActivity: 50,
-            ExtractedBibliographicResource: 10,
-            ExtractedConsent: 10,
-            ExtractedContactPoint: 5,
-            ExtractedDistribution: 50,
-            ExtractedOrganization: 5,
-            ExtractedOrganizationalUnit: 10,
-            ExtractedPerson: 100,
-            ExtractedResource: 70,
-            ExtractedVariable: 500,
-            ExtractedVariableGroup: 200,
-        },
-    )
+    """Create a list of identities for each of the model classes."""
+    return create_identities(faker)
 
 
 @asset(group_name="artificial")
@@ -84,8 +52,7 @@ def factories(faker: Faker, identities: IdentityMap) -> Faker:
 def artificial_data(factories: Faker, identities: IdentityMap) -> None:
     """Create artificial data and load the models to the sinks."""
     restore_identities(identities)  # restore state of memory identity provider
-    for model in EXTRACTED_MODEL_CLASSES:
-        load(factories.extracted_data(model))
+    load(m for c in EXTRACTED_MODEL_CLASSES for m in factories.extracted_data(c))
 
 
 @entrypoint(Settings)

--- a/mex/extractors/artificial/provider.py
+++ b/mex/extractors/artificial/provider.py
@@ -203,7 +203,7 @@ class TextProvider(PythonFakerProvider):
 class PatternProvider(BaseFakerProvider):
     """Faker provider to create strings matching given patterns."""
 
-    # XXX: Hardcoding is not an ideal but a quick way to get matching random strings
+    # TODO(ND): Try to avoid hardcoding the numerify patterns
     REGEX_TO_NUMERIFY = {
         r"^https://www\.wikidata\.org/entity/[PQ0-9]{2,64}$": "https://www.wikidata.org/entity/P######",
         r"^https://isni\.org/isni/[X0-9]{16}$": "https://isni.org/isni/################",

--- a/mex/extractors/artificial/settings.py
+++ b/mex/extractors/artificial/settings.py
@@ -1,6 +1,6 @@
 from pydantic import Field
 
-from mex.common.models import BaseModel
+from mex.common.models import EXTRACTED_MODEL_CLASSES, BaseModel
 from mex.common.types import AssetsPath
 
 
@@ -9,20 +9,11 @@ class ArtificialSettings(BaseModel):
 
     count: int = Field(
         100,
-        gt=10,
+        ge=len(EXTRACTED_MODEL_CLASSES) * 2,
         lt=10e6,
-        alias="c",
         description=(
-            "Amount of artificial entities to create. At least 2 per entity type will "
-            "be created regardless of setting or hardcoded weights."
-        ),
-    )
-    matched: int = Field(
-        25,
-        ge=0,
-        le=100,
-        description=(
-            "Integer percentage of matched items with same target ID to produce."
+            "Amount of artificial entities to create. At least 2 per entity type are "
+            "required, to ensure valid linking between the entities."
         ),
     )
     chattiness: int = Field(

--- a/tests/artificial/conftest.py
+++ b/tests/artificial/conftest.py
@@ -9,7 +9,7 @@ from mex.extractors.settings import Settings
 def reduce_output(settings: Settings) -> None:
     """Automatically reduce the chattiness for text fields and item count for tests."""
     settings.artificial.chattiness = 5
-    settings.artificial.count = 15
+    settings.artificial.count = settings.artificial.model_fields["count"].metadata[0].ge
 
 
 @pytest.fixture(name="faker")

--- a/tests/artificial/test_identity.py
+++ b/tests/artificial/test_identity.py
@@ -7,8 +7,6 @@ from mex.common.identity import get_provider
 from mex.common.identity.memory import MemoryIdentityProvider
 from mex.common.models import (
     EXTRACTED_MODEL_CLASSES,
-    ExtractedAccessPlatform,
-    ExtractedPrimarySource,
 )
 from mex.common.testing import Joker
 from mex.common.types import MergedPrimarySourceIdentifier
@@ -46,16 +44,21 @@ def test_restore_identities() -> None:
 
 
 def test_create_numeric_ids(faker: Faker) -> None:
-    numeric_ids = _create_numeric_ids(
-        faker,
-        {
-            ExtractedPrimarySource: 5,
-            ExtractedAccessPlatform: 2,
-        },
-    )
+    numeric_ids = _create_numeric_ids(faker)
     assert numeric_ids == {
-        "AccessPlatform": range(3427526317, 3427526324),
-        "PrimarySource": range(2516530558, 2516530566),
+        "AccessPlatform": [3427526317, 3427526318],
+        "Activity": [2405477151, 2405477152],
+        "BibliographicResource": [2035724763, 2035724764],
+        "Consent": [2933388007, 2933388008],
+        "ContactPoint": [4181830114, 4181830115],
+        "Distribution": [1589096615, 1589096616],
+        "Organization": [991028314, 991028315],
+        "OrganizationalUnit": [3284134756, 3284134757],
+        "Person": [639677827, 639677828],
+        "PrimarySource": [2516530558, 2516530559],
+        "Resource": [2676315731, 2676315732],
+        "Variable": [4015597000, 4015597001],
+        "VariableGroup": [1476619723, 1476619724],
     }
 
 
@@ -75,14 +78,8 @@ def test_get_offset_int() -> None:
 
 
 def test_create_identities(faker: Faker) -> None:
-    identity_map = create_identities(
-        faker,
-        {
-            ExtractedPrimarySource: 1,
-            ExtractedAccessPlatform: 3,
-        },
-    )
-    assert len(identity_map["AccessPlatform"]) > len(identity_map["PrimarySource"])
+    identity_map = create_identities(faker)
+    assert len(identity_map) == len(EXTRACTED_MODEL_CLASSES)
     assert identity_map["PrimarySource"][0].model_dump() == {
         "identifier": Joker(),
         "hadPrimarySource": "00000000000000",

--- a/tests/artificial/test_provider.py
+++ b/tests/artificial/test_provider.py
@@ -14,7 +14,6 @@ from mex.common.types import (
     Email,
     Identifier,
     Link,
-    LinkLanguage,
     MergedPrimarySourceIdentifier,
     TemporalEntity,
     TemporalEntityPrecision,
@@ -58,7 +57,7 @@ def test_builder_provider_min_max_for_field(faker: Faker) -> None:
     assert min_max == {
         "has_max": (0, 5),
         "has_min": (2, 5),
-        "is_inner_union": (0, 2),
+        "is_inner_union": (0, 1),
         "is_nested_pattern": (0, 2),
         "is_optional": (0, 1),
         "is_required": (1, 1),
@@ -76,7 +75,7 @@ def test_builder_provider_inner_type_and_pattern(faker: Faker) -> None:
     assert inner_types == {
         "has_min": (bytes, None),
         "has_max": (bytes, None),
-        "is_inner_union": (float, None),
+        "is_inner_union": (int, None),
         "is_nested_pattern": (
             str,
             "^https://gepris\\.dfg\\.de/gepris/institution/[0-9]{1,64}$",
@@ -98,32 +97,30 @@ def test_builder_provider_inner_type_and_pattern(faker: Faker) -> None:
         (
             Link,
             [
-                Link(
-                    language=LinkLanguage.DE, title="Cross", url="http://www.pratt.com/"
-                )
+                Link(language=None, title="Larsen", url="http://sanchez-nguyen.com/"),
             ],
         ),
-        (Email, ["john51@example.org"]),
+        (Email, ["cortezraymond@example.net"]),
         (
             Text,
             [
                 Text(
-                    value="Region as true develop sound central. Language ball floor meet usually board necessary.",
+                    value="Ability management test during foot that course nothing.",
                     language=TextLanguage.EN,
                 )
             ],
         ),
-        (TemporalEntity, [TemporalEntity("2023-07-12T01:42:54Z")]),
-        (APIType, [APIType["OTHER"]]),
+        (TemporalEntity, [TemporalEntity("1998-07-11T09:38:23Z")]),
+        (APIType, [APIType["REST"]]),
         (
             Annotated[Pattern, Field(pattern=r"^https://ror\.org/[a-z0-9]{9}$")],
-            ["https://ror.org/535139332"],
+            ["https://ror.org/160975351"],
         ),
         (
             Annotated[
                 str, Field(pattern=(r"^http://id\.nlm\.nih\.gov/mesh/[A-Z0-9]{2,64}$"))
             ],
-            ["http://id.nlm.nih.gov/mesh/D000022"],
+            ["http://id.nlm.nih.gov/mesh/D000006"],
         ),
         (
             list[
@@ -134,9 +131,9 @@ def test_builder_provider_inner_type_and_pattern(faker: Faker) -> None:
                     ),
                 ]
             ],
-            [],
+            ["https://gepris.dfg.de/gepris/institution/0975351"],
         ),
-        (str, ["either show"]),
+        (str, ["serve"]),
     ],
 )
 def test_builder_provider_field_value(
@@ -170,7 +167,8 @@ def test_builder_provider_extracted_data(faker: Faker) -> None:
     models = faker.extracted_data(ExtractedContactPoint)
     assert models[0].model_dump(exclude_defaults=True) == {
         "email": [
-            "jane13@example.net",
+            "salazarmaria@example.com",
+            "jessicapadilla@example.org",
         ],
         "hadPrimarySource": Joker(),
         "identifier": Joker(),
@@ -202,34 +200,35 @@ def test_identity_provider_reference(faker: Faker) -> None:
 
 
 def test_link_provider(faker: Faker) -> None:
-    assert faker.link() == Link(language=None, title=None, url="https://cross.com/")
+    assert faker.link() == Link(language=None, title=None, url="http://www.larsen.com/")
 
 
 def test_temporal_entity_provider(faker: Faker) -> None:
     assert faker.temporal_entity([TemporalEntityPrecision.DAY]) == TemporalEntity(
-        "2016-03-03"
+        "2022-09-28"
     )
 
 
 def test_text_provider_string(faker: Faker) -> None:
-    assert faker.text_string() == "minute their trip"
+    assert faker.text_string() == "whole address better"
 
 
 def test_text_provider_text(faker: Faker) -> None:
     assert faker.text_object() == Text(
-        value="During foot that course nothing draw. Sort language ball floor. Your majority feeling fact by four two. White owner onto knowledge other. First drug contain start almost wonder. Live bed serious theory type.",
+        value="Rest human station property. Partner stock four. "
+        "Region as true develop sound central.",
         language=TextLanguage.EN,
     )
 
 
 def test_pattern_provider(faker: Faker) -> None:
     pattern = faker.pattern(r"^https://ror\.org/[a-z0-9]{9}$")
-    assert pattern == "https://ror.org/975351393"
+    assert pattern == "https://ror.org/801609753"
 
     pattern = faker.pattern(
         "^(((http)|(https))://(dx.)?doi.org/)(10.\\d{4,9}/[-._;()/:A-Z0-9]+)$"
     )
-    assert pattern == "https://dx.doi.org/10.9489/2411578"
+    assert pattern == "https://dx.doi.org/10.8242/1948924"
 
     pattern = faker.pattern(r"^http://id\.nlm\.nih\.gov/mesh/[A-Z0-9]{2,64}$")
-    assert pattern == "http://id.nlm.nih.gov/mesh/D000016"
+    assert pattern == "http://id.nlm.nih.gov/mesh/D000007"


### PR DESCRIPTION
# PR Context
- main motivation was to restore determinism, ie running artificial extractor twice with same seed should get you the exact same data. this was ruined by the weight per types, i reckoned. at least after removing that i did get consistent data. i also removed and fixed some unused config options.

# Changes
- increase minimum valid artificial data count to two times the number of entity types

# Removed
- remove `matched` setting for the artificial extractor, since that was not implemented
- stop configuring entity-type weights for artificial data, since that broke determinism
- removed unused `-c` alias for the count setting of the artificial extractor
