### PR TITLE
Bump cookiecutter template to 57e9b7

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,12 +1,13 @@
 {
   "checkout": null,
-  "commit": "a4f25ab84f9e485ad77eb03663a9cf486f7a5826",
+  "commit": "57e9b752fed460f5542bda226467210d0135f4fb",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",
       "short_summary": "ETL pipelines for the RKI Metadata Exchange.",
       "long_summary": "The `mex-extractors` package implements a variety of ETL pipelines to **extract** metadata from primary data sources using a range of different technologies and protocols. Then, we **transform** the metadata into a standardized format using models provided by `mex-common`. The last step in this process is to **load** the harmonized metadata into a sink (file output, API upload, etc).",
-      "_template": "https://github.com/robert-koch-institut/mex-template"
+      "_template": "https://github.com/robert-koch-institut/mex-template",
+      "_commit": "57e9b752fed460f5542bda226467210d0135f4fb"
     }
   },
   "directory": null,

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -13,8 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PIP_NO_OPTION: on
+  PDM_CHECK_UPDATE: False
+  PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
+  PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
 
 jobs:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,8 +8,10 @@ on:
   workflow_dispatch:
 
 env:
-  PIP_NO_OPTION: on
+  PDM_CHECK_UPDATE: False
+  PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
+  PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
 
 permissions:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,8 +12,10 @@ on:
   workflow_dispatch:
 
 env:
-  PIP_NO_OPTION: on
+  PDM_CHECK_UPDATE: False
+  PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
+  PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,10 @@ on:
         required: true
 
 env:
-  PIP_NO_OPTION: on
+  PDM_CHECK_UPDATE: False
+  PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
+  PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
 
 permissions:
@@ -131,6 +133,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          ref: ${{ needs.release.outputs.tag }}
 
       - name: Cache requirements
         uses: actions/cache@v4
@@ -153,7 +156,6 @@ jobs:
       - name: Build wheel and sdist distros and create a github release
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-          PDM_CHECK_UPDATE: False
         run: |
           gh release create ${{ needs.release.outputs.tag }} --generate-notes --latest --verify-tag
           pdm build --dest dist

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,8 +12,10 @@ on:
   workflow_dispatch:
 
 env:
-  PIP_NO_OPTION: on
+  PDM_CHECK_UPDATE: False
+  PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
+  PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
 
 concurrency:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Robert Koch-Institut
+Copyright (c) 2025 Robert Koch-Institut
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/57e9b7

# Conflicts

```diff a/Dockerfile b/Dockerfile	(rejected hunks)
@@ -11,9 +11,10 @@ LABEL org.opencontainers.image.vendor="robert-koch-institut"
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONOPTIMIZE=1
 
-ENV PIP_PROGRESS_BAR=off
-ENV PIP_PREFER_BINARY=on
 ENV PIP_DISABLE_PIP_VERSION_CHECK=on
+ENV PIP_NO_INPUT: on
+ENV PIP_PREFER_BINARY=on
+ENV PIP_PROGRESS_BAR=off
 
 ENV MEX_EXTRACTORS_HOST=0.0.0.0
 
```

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v41.0.2
+        uses: renovatebot/github-action@v41.0.8
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-extractors"
```

```diff a/.pre-commit-config.yaml b/.pre-commit-config.yaml	(rejected hunks)
@@ -3,7 +3,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.3
+    rev: v0.9.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.20.1
+    rev: 2.22.2
     hooks:
       - id: pdm-lock-check
         name: pdm
```

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -15,7 +15,7 @@ optional-dependencies.dev = [
     "pytest-random-order>=1,<2",
     "pytest-xdist>=3,<4",
     "pytest>=8,<9",
-    "ruff>=0.7,<1",
+    "ruff>=0.9,<1",
     "sphinx>=8,<9",
 ]
 
@@ -138,5 +138,5 @@ known-first-party = ["mex", "tests"]
 convention = "google"
 
 [build-system]
-requires = ["pdm-backend==2.4.1"]
+requires = ["pdm-backend==2.4.3"]
 build-backend = "pdm.backend"
```

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,5 +1,4 @@
-cruft==2.15.0
+cruft==2.16.0
 mex-release==0.3.0
-pdm==2.20.1
+pdm==2.22.1
 pre-commit==4.0.1
-wheel==0.45.0
```
