### PR TITLE
Bump cookiecutter template to 7de6ba

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "ed5deb106b3d34aa758dcd4f4d3628a1ffb2b159",
+  "commit": "7de6bafd6cadfebd1fdaff228960adc884bb48b5",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",
       "short_summary": "ETL pipelines for the RKI Metadata Exchange.",
       "long_summary": "The `mex-extractors` package implements a variety of ETL pipelines to **extract** metadata from primary data sources using a range of different technologies and protocols. Then, we **transform** the metadata into a standardized format using models provided by `mex-common`. The last step in this process is to **load** the harmonized metadata into a sink (file output, API upload, etc).",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "ed5deb106b3d34aa758dcd4f4d3628a1ffb2b159"
+      "_commit": "7de6bafd6cadfebd1fdaff228960adc884bb48b5"
     }
   },
   "directory": null,


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/7de6ba
