### PR TITLE
change endnote identifier hyphenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- change endnote identifierInPrimarySource hyphenation
+
 ### Security
 
 ## [0.37.1] - 2025-07-01

--- a/mex/extractors/endnote/transform.py
+++ b/mex/extractors/endnote/transform.py
@@ -332,6 +332,7 @@ def extract_endnote_bibliographic_resource(  # noqa: C901, PLR0915
                 title_of_series.append(
                     Text(value=record.secondary_title, language=text_language),
                 )
+
         bibliographical_resources.append(
             ExtractedBibliographicResource(
                 abstract=abstract,
@@ -347,7 +348,7 @@ def extract_endnote_bibliographic_resource(  # noqa: C901, PLR0915
                 editor=editor,
                 editorOfSeries=editor_of_series,
                 hadPrimarySource=extracted_primary_source_endnote.stableTargetId,
-                identifierInPrimarySource=f"{record.database}\\n{record.rec_number}",
+                identifierInPrimarySource=f"{record.database}::{record.rec_number}",
                 isbnIssn=[record.isbn] if record.isbn else [],
                 issue=record.number,
                 issued=issued,
@@ -363,4 +364,5 @@ def extract_endnote_bibliographic_resource(  # noqa: C901, PLR0915
                 volume=record.volume,
             )
         )
+
     return bibliographical_resources

--- a/mex/extractors/endnote/transform.py
+++ b/mex/extractors/endnote/transform.py
@@ -332,7 +332,6 @@ def extract_endnote_bibliographic_resource(  # noqa: C901, PLR0915
                 title_of_series.append(
                     Text(value=record.secondary_title, language=text_language),
                 )
-
         bibliographical_resources.append(
             ExtractedBibliographicResource(
                 abstract=abstract,
@@ -364,5 +363,4 @@ def extract_endnote_bibliographic_resource(  # noqa: C901, PLR0915
                 volume=record.volume,
             )
         )
-
     return bibliographical_resources

--- a/tests/endnote/test_transform.py
+++ b/tests/endnote/test_transform.py
@@ -100,7 +100,7 @@ def test_extract_endnote_bibliographic_resource(
 
     assert bibliographic_resources[0].model_dump(exclude_defaults=True) == {
         "hadPrimarySource": str(extracted_primary_sources["endnote"].stableTargetId),
-        "identifierInPrimarySource": "1890-Converted.enl\\n1",
+        "identifierInPrimarySource": "1890-Converted.enl::1",
         "accessRestriction": "https://mex.rki.de/item/access-restriction-2",
         "doi": "https://doi.org/10.3456/qad.00",
         "issue": "6",


### PR DESCRIPTION
### Fixed

- change endnote identifierInPrimarySource hyphenation