### PR TITLE
mx_1938_avoid_endnote_identifier_collisions'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - change endnote identifierInPrimarySource hyphenation
+- avoid identifier collision in endnote organizations and persons
 
 ### Security
 

--- a/mex/extractors/endnote/transform.py
+++ b/mex/extractors/endnote/transform.py
@@ -58,7 +58,7 @@ def extract_endnote_persons_by_person_string(
             if len(split_name := person.split(",")) == 2 and split_name[1]:  # noqa: PLR2004
                 family_name, given_name = split_name
                 extracted_persons[person] = ExtractedPerson(
-                    identifierInPrimarySource=person,
+                    identifierInPrimarySource=f"Person_{person}",
                     hadPrimarySource=extracted_primary_source_endnote.stableTargetId,
                     familyName=family_name,
                     givenName=given_name,
@@ -68,7 +68,7 @@ def extract_endnote_persons_by_person_string(
                 continue
         else:
             extracted_persons[person] = ExtractedPerson(
-                identifierInPrimarySource=person,
+                identifierInPrimarySource=f"Person_{person}",
                 hadPrimarySource=extracted_primary_source_endnote.stableTargetId,
                 fullName=person,
             )
@@ -313,7 +313,7 @@ def extract_endnote_bibliographic_resource(  # noqa: C901, PLR0915
             else:
                 created_org = ExtractedOrganization(
                     hadPrimarySource=extracted_primary_source_endnote.stableTargetId,
-                    identifierInPrimarySource=publisher_string,
+                    identifierInPrimarySource=f"Organization_{publisher_string}",
                     officialName=[publisher_string],
                 )
                 load([created_org])

--- a/tests/endnote/test_transform.py
+++ b/tests/endnote/test_transform.py
@@ -32,7 +32,7 @@ def test_extract_endnote_persons_by_person_string(
     ]
     assert person_dict["Mustermann, J."].model_dump(exclude_defaults=True) == {
         "hadPrimarySource": extracted_primary_sources["endnote"].stableTargetId,
-        "identifierInPrimarySource": "Mustermann, J.",
+        "identifierInPrimarySource": "Person_Mustermann, J.",
         "familyName": ["Mustermann"],
         "fullName": ["Mustermann, J."],
         "givenName": ["J."],
@@ -127,7 +127,7 @@ def test_extract_endnote_bibliographic_resource(
             {"value": "keyword 2", "language": TextLanguage.EN},
         ],
         "language": ["https://mex.rki.de/item/language-2"],
-        "publisher": ["fPVAifNTaeeWWarVB5nk8U", "fPVAifNTaeeWWarVB5nk8U"],
+        "publisher": ["dKesJpFog76YEZ4BhPwKuF", "dKesJpFog76YEZ4BhPwKuF"],
         "identifier": Joker(),
         "stableTargetId": Joker(),
     }


### PR DESCRIPTION
### PR Context
- address issue more comprehensively in MX-1938

### Fixed

- avoid identifier collision in endnote organizations and persons