### PR TITLE
feature/return-loaded-assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- add return values to all assets for debugging and bookkeeping
+
 ### Changes
 
 - improve usage of backend endpoints for merged items

--- a/mex/extractors/artificial/main.py
+++ b/mex/extractors/artificial/main.py
@@ -3,14 +3,18 @@ from dagster import asset
 from mex.artificial.helpers import generate_artificial_extracted_items
 from mex.artificial.main import DEFAULT_LOCALE
 from mex.common.cli import entrypoint
-from mex.common.models import EXTRACTED_MODEL_CLASSES_BY_NAME, AnyExtractedModel
+from mex.common.models import (
+    EXTRACTED_MODEL_CLASSES_BY_NAME,
+    AnyExtractedModel,
+    ItemsContainer,
+)
 from mex.extractors.pipeline import run_job_in_process
 from mex.extractors.settings import Settings
 from mex.extractors.sinks import load
 
 
 @asset(group_name="artificial")
-def artificial_data() -> list[AnyExtractedModel]:
+def artificial_data() -> ItemsContainer[AnyExtractedModel]:
     """Load the artificial data models to the sinks."""
     artificial_data = generate_artificial_extracted_items(
         locale=DEFAULT_LOCALE,
@@ -20,7 +24,7 @@ def artificial_data() -> list[AnyExtractedModel]:
         stem_types=list(EXTRACTED_MODEL_CLASSES_BY_NAME),
     )
     load(artificial_data)
-    return artificial_data
+    return ItemsContainer[AnyExtractedModel](items=artificial_data)
 
 
 @entrypoint(Settings)

--- a/mex/extractors/artificial/main.py
+++ b/mex/extractors/artificial/main.py
@@ -3,14 +3,14 @@ from dagster import asset
 from mex.artificial.helpers import generate_artificial_extracted_items
 from mex.artificial.main import DEFAULT_LOCALE
 from mex.common.cli import entrypoint
-from mex.common.models import EXTRACTED_MODEL_CLASSES_BY_NAME
+from mex.common.models import EXTRACTED_MODEL_CLASSES_BY_NAME, AnyExtractedModel
 from mex.extractors.pipeline import run_job_in_process
 from mex.extractors.settings import Settings
 from mex.extractors.sinks import load
 
 
 @asset(group_name="artificial")
-def artificial_data() -> None:
+def artificial_data() -> list[AnyExtractedModel]:
     """Load the artificial data models to the sinks."""
     artificial_data = generate_artificial_extracted_items(
         locale=DEFAULT_LOCALE,
@@ -20,6 +20,7 @@ def artificial_data() -> None:
         stem_types=list(EXTRACTED_MODEL_CLASSES_BY_NAME),
     )
     load(artificial_data)
+    return artificial_data
 
 
 @entrypoint(Settings)

--- a/mex/extractors/blueant/main.py
+++ b/mex/extractors/blueant/main.py
@@ -5,6 +5,7 @@ from mex.common.ldap.extract import get_merged_ids_by_employee_ids
 from mex.common.ldap.transform import transform_ldap_persons_to_mex_persons
 from mex.common.models import (
     ActivityMapping,
+    ExtractedActivity,
     ExtractedOrganizationalUnit,
     ExtractedPrimarySource,
 )
@@ -91,22 +92,25 @@ def extracted_blueant_activities(
     blueant_project_leaders_by_employee_id: dict[str, list[MergedPersonIdentifier]],
     unit_stable_target_ids_by_synonym: dict[str, MergedOrganizationalUnitIdentifier],
     blueant_organization_ids_by_query_string: dict[str, MergedOrganizationIdentifier],
-) -> None:
+) -> list[ExtractedActivity]:
     """Transform blueant sources to extracted activities and load them to the sinks."""
     settings = Settings.get()
     activity = ActivityMapping.model_validate(
         load_yaml(settings.blueant.mapping_path / "activity.yaml")
     )
 
-    extracted_activities = transform_blueant_sources_to_extracted_activities(
-        blueant_sources,
-        extracted_primary_source_blueant,
-        blueant_project_leaders_by_employee_id,
-        unit_stable_target_ids_by_synonym,
-        activity,
-        blueant_organization_ids_by_query_string,
+    extracted_activities = list(
+        transform_blueant_sources_to_extracted_activities(
+            blueant_sources,
+            extracted_primary_source_blueant,
+            blueant_project_leaders_by_employee_id,
+            unit_stable_target_ids_by_synonym,
+            activity,
+            blueant_organization_ids_by_query_string,
+        )
     )
     load(extracted_activities)
+    return extracted_activities
 
 
 @entrypoint(Settings)

--- a/mex/extractors/contact_point/main.py
+++ b/mex/extractors/contact_point/main.py
@@ -10,15 +10,18 @@ from mex.extractors.sinks import load
 @asset(group_name="contact_point")
 def extracted_contact_point_mex(
     extracted_primary_source_mex: ExtractedPrimarySource,
-) -> None:
-    """Load and return blueant primary source."""
+) -> list[ExtractedContactPoint]:
+    """Load and return default contact points."""
     settings = Settings.get()
-    extracted_contact_point = ExtractedContactPoint(
-        identifierInPrimarySource=str(settings.contact_point.mex_email),
-        hadPrimarySource=extracted_primary_source_mex.stableTargetId,
-        email=[settings.contact_point.mex_email],
-    )
-    load([extracted_contact_point])
+    extracted_contact_points = [
+        ExtractedContactPoint(
+            identifierInPrimarySource=str(settings.contact_point.mex_email),
+            hadPrimarySource=extracted_primary_source_mex.stableTargetId,
+            email=[settings.contact_point.mex_email],
+        )
+    ]
+    load(extracted_contact_points)
+    return extracted_contact_points
 
 
 @entrypoint(Settings)

--- a/mex/extractors/endnote/main.py
+++ b/mex/extractors/endnote/main.py
@@ -4,6 +4,8 @@ from mex.common.cli import entrypoint
 from mex.common.models import (
     BibliographicResourceMapping,
     ConsentMapping,
+    ExtractedBibliographicResource,
+    ExtractedConsent,
     ExtractedPerson,
     ExtractedPrimarySource,
 )
@@ -59,7 +61,7 @@ def extracted_endnote_persons_by_person_string(
 def extracted_endnote_consents(
     extracted_endnote_persons_by_person_string: dict[str, ExtractedPerson],
     extracted_primary_source_endnote: ExtractedPrimarySource,
-) -> None:
+) -> list[ExtractedConsent]:
     """Extract records from endnote."""
     settings = Settings.get()
     endnote_consent_mapping = ConsentMapping.model_validate(
@@ -71,6 +73,7 @@ def extracted_endnote_consents(
         endnote_consent_mapping,
     )
     load(extracted_endnote_consents)
+    return extracted_endnote_consents
 
 
 @asset(group_name="endnote")
@@ -79,7 +82,7 @@ def extracted_endnote_bibliographic_resources(
     extracted_endnote_persons_by_person_string: dict[str, ExtractedPerson],
     unit_stable_target_ids_by_synonym: dict[str, MergedOrganizationalUnitIdentifier],
     extracted_primary_source_endnote: ExtractedPrimarySource,
-) -> None:
+) -> list[ExtractedBibliographicResource]:
     """Extract bibliographic resources from endnote."""
     settings = Settings.get()
     endnote_bibliographic_resource_mapping = (
@@ -95,6 +98,7 @@ def extracted_endnote_bibliographic_resources(
         extracted_primary_source_endnote,
     )
     load(extracted_bibliographic_resource)
+    return extracted_bibliographic_resource
 
 
 @entrypoint(Settings)

--- a/mex/extractors/grippeweb/main.py
+++ b/mex/extractors/grippeweb/main.py
@@ -15,6 +15,7 @@ from mex.common.models import (
     ExtractedPerson,
     ExtractedPrimarySource,
     ExtractedResource,
+    ExtractedVariable,
     ExtractedVariableGroup,
     ResourceMapping,
     VariableGroupMapping,
@@ -221,7 +222,7 @@ def grippeweb_extracted_variable(
     grippeweb_columns: dict[str, dict[str, list[Any]]],
     grippeweb_extracted_parent_resource: ExtractedResource,
     extracted_primary_source_grippeweb: ExtractedPrimarySource,
-) -> None:
+) -> list[ExtractedVariable]:
     """Transform Grippeweb default values to extracted variables and load to sinks."""
     extracted_variables = transform_grippeweb_variable_to_extracted_variables(
         VariableMapping.model_validate(grippeweb_variable),
@@ -231,6 +232,7 @@ def grippeweb_extracted_variable(
         extracted_primary_source_grippeweb,
     )
     load(extracted_variables)
+    return extracted_variables
 
 
 @entrypoint(Settings)

--- a/mex/extractors/ifsg/main.py
+++ b/mex/extractors/ifsg/main.py
@@ -7,6 +7,7 @@ from mex.common.models import (
     ExtractedOrganization,
     ExtractedPrimarySource,
     ExtractedResource,
+    ExtractedVariable,
     ExtractedVariableGroup,
     ResourceMapping,
     VariableGroupMapping,
@@ -259,7 +260,7 @@ def extracted_ifsg_variable(  # noqa: PLR0913
     meta_item: list[MetaItem],
     meta_datatype: list[MetaDataType],
     meta_schema2field: list[MetaSchema2Field],
-) -> None:
+) -> list[ExtractedVariable]:
     """Extracted and loaded ifsg variable."""
     extracted_variables = transform_ifsg_data_to_mex_variables(
         filtered_variables,
@@ -273,6 +274,7 @@ def extracted_ifsg_variable(  # noqa: PLR0913
         meta_schema2field,
     )
     load(extracted_variables)
+    return extracted_variables
 
 
 @entrypoint(Settings)

--- a/mex/extractors/odk/main.py
+++ b/mex/extractors/odk/main.py
@@ -8,6 +8,7 @@ from mex.common.models import (
     ExtractedActivity,
     ExtractedPrimarySource,
     ExtractedResource,
+    ExtractedVariable,
     ResourceMapping,
 )
 from mex.common.primary_source.transform import get_primary_sources_by_name
@@ -95,7 +96,7 @@ def extracted_variables_odk(
     extracted_resources_odk: list[ExtractedResource],
     odk_raw_data: list[ODKData],
     extracted_primary_source_odk: ExtractedPrimarySource,
-) -> None:
+) -> list[ExtractedVariable]:
     """Transform odk data to mex variables and load to sinks."""
     extracted_variables = transform_odk_data_to_extracted_variables(
         extracted_resources_odk,
@@ -104,6 +105,7 @@ def extracted_variables_odk(
     )
 
     load(extracted_variables)
+    return extracted_variables
 
 
 @entrypoint(Settings)

--- a/mex/extractors/seq_repo/main.py
+++ b/mex/extractors/seq_repo/main.py
@@ -141,7 +141,6 @@ def seq_repo_extracted_access_platform(
         )
     )
     load([mex_access_platform])
-
     return mex_access_platform
 
 
@@ -164,7 +163,7 @@ def seq_repo_resource(  # noqa: PLR0913
         load_yaml(settings.seq_repo.mapping_path / "resource.yaml")
     )
 
-    return transform_seq_repo_resource_to_extracted_resource(
+    resources = transform_seq_repo_resource_to_extracted_resource(
         seq_repo_latest_source,
         extracted_activity,
         seq_repo_extracted_access_platform,
@@ -175,12 +174,8 @@ def seq_repo_resource(  # noqa: PLR0913
         extracted_organization_rki,
         extracted_primary_source_seq_repo,
     )
-
-
-@asset(group_name="seq_repo")
-def load_seq_repo_resource(seq_repo_resource: list[ExtractedResource]) -> None:
-    """Load seq-repo resources."""
-    load(seq_repo_resource)
+    load(resources)
+    return resources
 
 
 @entrypoint(Settings)

--- a/mex/extractors/synopse/main.py
+++ b/mex/extractors/synopse/main.py
@@ -18,6 +18,7 @@ from mex.common.models import (
     ExtractedOrganizationalUnit,
     ExtractedPrimarySource,
     ExtractedResource,
+    ExtractedVariable,
     ExtractedVariableGroup,
     ResourceMapping,
 )
@@ -305,15 +306,18 @@ def extracted_synopse_variables(
     extracted_primary_source_report_server: ExtractedPrimarySource,
     extracted_synopse_variable_groups: list[ExtractedVariableGroup],
     extracted_synopse_resources_by_synopse_id: dict[str, ExtractedResource],
-) -> None:
+) -> list[ExtractedVariable]:
     """Transforms Synopse data to extracted variables and load result."""
-    extracted_variables = transform_synopse_variables_to_mex_variables(
-        synopse_variables_by_thema,
-        extracted_synopse_variable_groups,
-        extracted_synopse_resources_by_synopse_id,
-        extracted_primary_source_report_server,
+    extracted_variables = list(
+        transform_synopse_variables_to_mex_variables(
+            synopse_variables_by_thema,
+            extracted_synopse_variable_groups,
+            extracted_synopse_resources_by_synopse_id,
+            extracted_primary_source_report_server,
+        )
     )
     load(extracted_variables)
+    return extracted_variables
 
 
 @entrypoint(Settings)

--- a/mex/extractors/voxco/main.py
+++ b/mex/extractors/voxco/main.py
@@ -12,6 +12,7 @@ from mex.common.models import (
     ExtractedPerson,
     ExtractedPrimarySource,
     ExtractedResource,
+    ExtractedVariable,
     ResourceMapping,
 )
 from mex.common.primary_source.transform import get_primary_sources_by_name
@@ -125,12 +126,13 @@ def extracted_variables_voxco(
     extracted_voxco_resources: dict[str, ExtractedResource],
     voxco_variables: dict[str, list[VoxcoVariable]],
     extracted_primary_source_voxco: ExtractedPrimarySource,
-) -> None:
+) -> list[ExtractedVariable]:
     """Transform voxco variables and load them to the sinks."""
     extracted_variables = transform_voxco_variable_mappings_to_extracted_variables(
         extracted_voxco_resources, voxco_variables, extracted_primary_source_voxco
     )
     load(extracted_variables)
+    return extracted_variables
 
 
 @entrypoint(Settings)


### PR DESCRIPTION
### PR Context

I wanted to debug one of the assets that just had a "load" statement in the last line, but no return. The lack of a return statement made it impossible to inspect the asset in the dagster storage, because it was not materialized to disk. This PR adds return values to all assets to make debugging easier in the future.

### Added

- add return values to all assets for debugging and bookkeeping