### PR TITLE
feature/fix-consent-mailer-settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- make consent mailer settings inherit from BaseModel
+
 ### Security
 
 ## [1.0.0] - 2025-09-04

--- a/mex/extractors/consent_mailer/settings.py
+++ b/mex/extractors/consent_mailer/settings.py
@@ -1,10 +1,10 @@
 from pydantic import Field, SecretStr
 
-from mex.common.settings import BaseSettings
+from mex.common.models import BaseModel
 from mex.common.types import AssetsPath
 
 
-class ConsentMailerSettings(BaseSettings):
+class ConsentMailerSettings(BaseModel):
     """Settings definition class for the consent mailer."""
 
     mailpit_api_url: str = Field(


### PR DESCRIPTION
### Fixed
- make consent mailer settings inherit from BaseModel
