### PR TITLE
Feature/mx 1947 point5 dry beautiful soup point6 add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- datenkompass: add function for html-link handling, add tests
+
 ### Changes
 
 ### Deprecated

--- a/mex/extractors/datenkompass/transform.py
+++ b/mex/extractors/datenkompass/transform.py
@@ -222,6 +222,8 @@ def get_abstract_or_description(abstracts: list[Text], delim: str) -> str:
     Returns:
         joined german strings with reformated plain text urls.
     """
+    if not abstracts:
+        return ""
     abstract_string = delim.join(get_german_text(abstracts))
     soup_string = BeautifulSoup(abstract_string, "html.parser")
     for a in soup_string.find_all("a", href=True):
@@ -249,8 +251,7 @@ def transform_activities(
     datenkompass_activities = []
     for item in filtered_merged_activities:
         beschreibung = "Es handelt sich um ein Projekt/ Vorhaben. "
-        if item.abstract:
-            beschreibung += get_abstract_or_description(item.abstract, delim)
+        beschreibung += get_abstract_or_description(item.abstract, delim)
         kontakt = get_email(
             item.responsibleUnit,
             merged_organizational_units_by_id,
@@ -337,8 +338,7 @@ def transform_bibliographic_resources(
         titel = f"{title_collection} ({creator_collection})"
         vocab = get_german_vocabulary(item.bibliographicResourceType)
         beschreibung = f"{delim.join(v for v in vocab if v is not None)}. "
-        if item.abstract:
-            beschreibung += get_abstract_or_description(item.abstract, delim)
+        beschreibung += get_abstract_or_description(item.abstract, delim)
         datenkompass_bibliographic_recources.append(
             DatenkompassBibliographicResource(
                 beschreibung=beschreibung,
@@ -421,9 +421,11 @@ def transform_resources(
             organisationseinheit = get_unit_shortname(
                 item.unitInCharge, merged_organizational_units_by_id
             )
-            beschreibung = "n/a"
-            if item.description:
-                beschreibung = get_abstract_or_description(item.description, delim)
+            beschreibung = (
+                get_abstract_or_description(item.description, delim)
+                if item.description
+                else "n/a"
+            )
             rechtsgrundlagen_benennung = [
                 *[entry.value for entry in item.hasLegalBasis],
                 *get_german_vocabulary([item.license] if item.license else []),

--- a/mex/extractors/datenkompass/transform.py
+++ b/mex/extractors/datenkompass/transform.py
@@ -175,7 +175,7 @@ def get_title(item: MergedActivity) -> list[str]:
     return collected_titles
 
 
-def get_vocabulary(
+def get_german_vocabulary(
     entries: list[_VocabularyT],
 ) -> list[str | None]:
     """Get german prefLabel for Vocabularies.
@@ -259,7 +259,7 @@ def transform_activities(
             merged_organizational_units_by_id,
         )
         titel = get_title(item)
-        schlagwort = get_vocabulary(item.theme)
+        schlagwort = get_german_vocabulary(item.theme)
         datenbank = []
         if item.website:
             url_de = [w.url for w in item.website if w.language == "de"]
@@ -334,8 +334,8 @@ def transform_bibliographic_resources(
         if len(item.creator) > max_number_authors_cutoff:
             creator_collection += " / et al."
         titel = f"{title_collection} ({creator_collection})"
-        vocab = get_vocabulary(item.bibliographicResourceType)
-        beschreibung = f"{delim.join(s for s in vocab if s is not None)}. "
+        vocab = get_german_vocabulary(item.bibliographicResourceType)
+        beschreibung = f"{delim.join(v for v in vocab if v is not None)}. "
         if item.abstract:
             b2 = delim.join(get_german_text(item.abstract))
             beschreibung += reformat_html_links(b2)
@@ -409,7 +409,7 @@ def transform_resources(
             elif item.accessRestriction == AccessRestriction["OPEN"]:
                 voraussetzungen = "Frei zugänglich"
             frequenz = (
-                get_vocabulary([item.accrualPeriodicity])
+                get_german_vocabulary([item.accrualPeriodicity])
                 if item.accrualPeriodicity
                 else []
             )
@@ -427,10 +427,10 @@ def transform_resources(
                 beschreibung = reformat_html_links(b2)
             rechtsgrundlagen_benennung = [
                 *[entry.value for entry in item.hasLegalBasis],
-                *get_vocabulary([item.license] if item.license else []),
+                *get_german_vocabulary([item.license] if item.license else []),
             ]
             schlagwort = [
-                *get_vocabulary(item.theme),
+                *get_german_vocabulary(item.theme),
                 *[entry.value for entry in item.keyword],
             ]
             datennutzungszweck = datennutzungszweck_by_primary_source[primary_source]

--- a/mex/extractors/datenkompass/transform.py
+++ b/mex/extractors/datenkompass/transform.py
@@ -212,16 +212,18 @@ def get_datenbank(item: MergedBibliographicResource) -> str | None:
     return None
 
 
-def reformat_html_links(string: str) -> str:
-    """Reformat html-formated links in string into plain text urls.
+def get_abstract_or_description(abstracts: list[Text], delim: str) -> str:
+    """Get German list entries, join them and reformat html-formated links.
 
     Args:
-        string: string with possible html-formated links
+        abstracts: list of mixed language strings with possible html-formated links
+        delim: list delimiter for joining the strings in list
 
     Returns:
-        string with reformated plain text urls.
+        joined german strings with reformated plain text urls.
     """
-    soup_string = BeautifulSoup(string, "html.parser")
+    abstract_string = delim.join(get_german_text(abstracts))
+    soup_string = BeautifulSoup(abstract_string, "html.parser")
     for a in soup_string.find_all("a", href=True):
         a.replace_with(a["href"])
     return str(soup_string)
@@ -248,8 +250,7 @@ def transform_activities(
     for item in filtered_merged_activities:
         beschreibung = "Es handelt sich um ein Projekt/ Vorhaben. "
         if item.abstract:
-            b2 = delim.join(get_german_text(item.abstract))
-            beschreibung += reformat_html_links(b2)
+            beschreibung += get_abstract_or_description(item.abstract, delim)
         kontakt = get_email(
             item.responsibleUnit,
             merged_organizational_units_by_id,
@@ -337,8 +338,7 @@ def transform_bibliographic_resources(
         vocab = get_german_vocabulary(item.bibliographicResourceType)
         beschreibung = f"{delim.join(v for v in vocab if v is not None)}. "
         if item.abstract:
-            b2 = delim.join(get_german_text(item.abstract))
-            beschreibung += reformat_html_links(b2)
+            beschreibung += get_abstract_or_description(item.abstract, delim)
         datenkompass_bibliographic_recources.append(
             DatenkompassBibliographicResource(
                 beschreibung=beschreibung,
@@ -423,8 +423,7 @@ def transform_resources(
             )
             beschreibung = "n/a"
             if item.description:
-                b2 = delim.join(get_german_text(item.description))
-                beschreibung = reformat_html_links(b2)
+                beschreibung = get_abstract_or_description(item.description, delim)
             rechtsgrundlagen_benennung = [
                 *[entry.value for entry in item.hasLegalBasis],
                 *get_german_vocabulary([item.license] if item.license else []),

--- a/mex/extractors/datenkompass/transform.py
+++ b/mex/extractors/datenkompass/transform.py
@@ -212,6 +212,21 @@ def get_datenbank(item: MergedBibliographicResource) -> str | None:
     return None
 
 
+def reformat_html_links(string: str) -> str:
+    """Reformat html-formated links in string into plain text urls.
+
+    Args:
+        string: string with possible html-formated links
+
+    Returns:
+        string with reformated plain text urls.
+    """
+    soup_string = BeautifulSoup(string, "html.parser")
+    for a in soup_string.find_all("a", href=True):
+        a.replace_with(a["href"])
+    return str(soup_string)
+
+
 def transform_activities(
     filtered_merged_activities: list[MergedActivity],
     merged_organizational_units_by_id: dict[
@@ -233,11 +248,8 @@ def transform_activities(
     for item in filtered_merged_activities:
         beschreibung = "Es handelt sich um ein Projekt/ Vorhaben. "
         if item.abstract:
-            beschreibung += delim.join(get_german_text(item.abstract))
-            beschreibung_soup = BeautifulSoup(beschreibung, "html.parser")
-            for a in beschreibung_soup.find_all("a", href=True):
-                a.replace_with(a["href"])
-            beschreibung = str(beschreibung_soup)
+            b2 = delim.join(get_german_text(item.abstract))
+            beschreibung += reformat_html_links(b2)
         kontakt = get_email(
             item.responsibleUnit,
             merged_organizational_units_by_id,
@@ -326,10 +338,7 @@ def transform_bibliographic_resources(
         beschreibung = f"{delim.join(s for s in vocab if s is not None)}. "
         if item.abstract:
             b2 = delim.join(get_german_text(item.abstract))
-            beschreibung_soup = BeautifulSoup(b2, "html.parser")
-            for a in beschreibung_soup.find_all("a", href=True):
-                a.replace_with(a["href"])
-            beschreibung += str(beschreibung_soup)
+            beschreibung += reformat_html_links(b2)
         datenkompass_bibliographic_recources.append(
             DatenkompassBibliographicResource(
                 beschreibung=beschreibung,
@@ -414,11 +423,8 @@ def transform_resources(
             )
             beschreibung = "n/a"
             if item.description:
-                beschreibung = delim.join(get_german_text(item.description))
-                beschreibung_soup = BeautifulSoup(beschreibung, "html.parser")
-                for a in beschreibung_soup.find_all("a", href=True):
-                    a.replace_with(a["href"])
-                beschreibung = str(beschreibung_soup)
+                b2 = delim.join(get_german_text(item.description))
+                beschreibung = reformat_html_links(b2)
             rechtsgrundlagen_benennung = [
                 *[entry.value for entry in item.hasLegalBasis],
                 *get_vocabulary([item.license] if item.license else []),

--- a/tests/datenkompass/test_transform.py
+++ b/tests/datenkompass/test_transform.py
@@ -18,10 +18,10 @@ from mex.extractors.datenkompass.transform import (
     get_datenbank,
     get_email,
     get_german_text,
+    get_german_vocabulary,
     get_resource_email,
     get_title,
     get_unit_shortname,
-    get_vocabulary,
     reformat_html_links,
     transform_activities,
     transform_bibliographic_resources,
@@ -114,8 +114,8 @@ def test_get_title(mocked_merged_activities: list[MergedActivity]) -> None:
     assert result == ["short de", "title 'Act' no language", "title en"]
 
 
-def test_get_vocabulary() -> None:
-    result = get_vocabulary([Theme["INFECTIOUS_DISEASES_AND_EPIDEMIOLOGY"]])
+def test_get_german_vocabulary() -> None:
+    result = get_german_vocabulary([Theme["INFECTIOUS_DISEASES_AND_EPIDEMIOLOGY"]])
     assert result == ["Infektionskrankheiten und -epidemiologie"]
 
 

--- a/tests/datenkompass/test_transform.py
+++ b/tests/datenkompass/test_transform.py
@@ -15,6 +15,7 @@ from mex.extractors.datenkompass.models.item import (
 )
 from mex.extractors.datenkompass.transform import (
     fix_quotes,
+    get_abstract_or_description,
     get_datenbank,
     get_email,
     get_german_text,
@@ -22,7 +23,6 @@ from mex.extractors.datenkompass.transform import (
     get_resource_email,
     get_title,
     get_unit_shortname,
-    reformat_html_links,
     transform_activities,
     transform_bibliographic_resources,
     transform_resources,
@@ -127,12 +127,14 @@ def test_get_datenbank(
     )
 
 
-def test_reformat_html_links() -> None:
-    test_string = (
-        'This is a <b>text</b> with <a href="https://link.url">Link text</a>, duh!'
-    )
-    assert reformat_html_links(test_string) == (
-        "This is a <b>text</b> with https://link.url, duh!"
+def test_get_abstract_or_description() -> None:
+    test_abstracts = [
+        Text(value="This is a <b>text</b>", language="de"),
+        Text(value='with a <a href="https://link.url">Link text</a>.', language="de"),
+    ]
+    delimiter = "; "
+    assert get_abstract_or_description(test_abstracts, delimiter) == (
+        "This is a <b>text</b>; with a https://link.url."
     )
 
 

--- a/tests/datenkompass/test_transform.py
+++ b/tests/datenkompass/test_transform.py
@@ -150,6 +150,7 @@ def test_get_abstract_or_description() -> None:
     assert get_abstract_or_description(test_abstracts, delimiter) == (
         "This is a <b>text</b>; with a https://link.url."
     )
+    assert get_abstract_or_description([], delimiter) == ""
 
 
 def test_transform_activities(

--- a/tests/datenkompass/test_transform.py
+++ b/tests/datenkompass/test_transform.py
@@ -89,22 +89,36 @@ def test_get_resource_email(
     assert result == "unit@example.org"
 
 
-def test_get_german_text() -> None:
-    test_texts = [
-        Text(value='deu "1"."', language="de"),
-        Text(value="deu 2", language="de"),
-        Text(value='"eng"li"sh"', language="en"),
-        Text(value="null", language=None),
-    ]
-
-    assert get_german_text(test_texts) == [  # get only 'de' entries, if available
-        "deu '1'.",
-        "deu 2",
-    ]
-    assert get_german_text(test_texts[2:]) == [  # return orig input, if no 'de' entry
-        "eng'li'sh",
-        "null",
-    ]
+@pytest.mark.parametrize(
+    ("text_entries", "expected"),
+    [
+        (
+            [
+                Text(value='deu "1"."', language="de"),
+                Text(value="deu 2", language="de"),
+                Text(value='"eng"li"sh"', language="en"),
+                Text(value="null", language=None),
+            ],
+            [
+                "deu '1'.",
+                "deu 2",
+            ],
+        ),
+        (
+            [
+                Text(value='"eng"li"sh"', language="en"),
+                Text(value="null", language=None),
+            ],
+            [
+                "eng'li'sh",
+                "null",
+            ],
+        ),
+    ],
+    ids=["german and other languages mixed", "only non-german entries"],
+)
+def test_get_german_text(text_entries: list[Text], expected: list[str]) -> None:
+    assert get_german_text(text_entries) == expected
 
 
 def test_get_title(mocked_merged_activities: list[MergedActivity]) -> None:

--- a/tests/datenkompass/test_transform.py
+++ b/tests/datenkompass/test_transform.py
@@ -19,6 +19,7 @@ from mex.extractors.datenkompass.transform import (
     get_title,
     get_unit_shortname,
     get_vocabulary,
+    reformat_html_links,
     transform_activities,
     transform_bibliographic_resources,
     transform_resources,
@@ -94,6 +95,15 @@ def test_get_datenbank(
 ) -> None:
     assert get_datenbank(mocked_merged_bibliographic_resource[0]) == (
         "https://doi.org/10.1234_find_this"
+    )
+
+
+def test_reformat_html_links() -> None:
+    test_string = (
+        'This is a <b>text</b> with <a href="https://link.url">Link text</a>, duh!'
+    )
+    assert reformat_html_links(test_string) == (
+        "This is a <b>text</b> with https://link.url, duh!"
     )
 
 


### PR DESCRIPTION
### Added
- datenkompass: add function for html-link handling, add tests

I also made the naming of the "get_vocabulary" function a bit more self-explanatory