### PR TITLE
Feature/mx 2027 consentmailer fix url too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- consent-mailer: fetch consent from DB in batches, to fix "URL too long" error
+
 ### Security
 
 ## [1.3.0] - 2025-10-14

--- a/mex/extractors/consent_mailer/extract.py
+++ b/mex/extractors/consent_mailer/extract.py
@@ -34,7 +34,7 @@ def extract_consents_for_persons(
     if not person_ids:
         return []
 
-    chunk_size = settings.consent_mailer.request_filter_chunck_size
+    chunk_size = settings.consent_mailer.backend_fetch_chunk_size
     collected_merged_consents: list[MergedConsent] = []
     for i in range(0, len(person_ids), chunk_size):
         partial_person_ids = person_ids[i : i + chunk_size]

--- a/mex/extractors/consent_mailer/extract.py
+++ b/mex/extractors/consent_mailer/extract.py
@@ -3,6 +3,7 @@ from typing import cast
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.models import MergedConsent, MergedPerson
 from mex.common.types import MergedPrimarySourceIdentifier
+from mex.extractors.settings import Settings
 
 
 def extract_ldap_persons(
@@ -26,19 +27,26 @@ def extract_consents_for_persons(
     person_items: list[MergedPerson],
 ) -> list[MergedConsent]:
     """Get consents for ldap persons."""
+    settings = Settings.get()
     connector = BackendApiConnector.get()
     person_ids = [str(person.identifier) for person in person_items]
 
     if not person_ids:
         return []
 
-    return cast(
-        "list[MergedConsent]",
-        list(
-            connector.fetch_all_merged_items(
-                entity_type=["MergedConsent"],
-                reference_field="hasDataSubject" if person_ids else None,
-                referenced_identifier=person_ids,
-            )
-        ),
-    )
+    chunk_size = settings.consent_mailer.request_filter_chunck_size
+    collected_merged_consents: list[MergedConsent] = []
+    for i in range(0, len(person_ids), chunk_size):
+        partial_person_ids = person_ids[i : i + chunk_size]
+        partial_merged_consents = cast(
+            "list[MergedConsent]",
+            list(
+                connector.fetch_all_merged_items(
+                    entity_type=["MergedConsent"],
+                    reference_field="hasDataSubject" if partial_person_ids else None,
+                    referenced_identifier=partial_person_ids,
+                )
+            ),
+        )
+        collected_merged_consents.extend(partial_merged_consents)
+    return collected_merged_consents

--- a/mex/extractors/consent_mailer/settings.py
+++ b/mex/extractors/consent_mailer/settings.py
@@ -7,7 +7,10 @@ from mex.common.types import AssetsPath
 class ConsentMailerSettings(BaseModel):
     """Settings definition class for the consent mailer."""
 
-    request_filter_chunck_size: int = 1
+    backend_fetch_chunk_size: int = Field(
+        1,
+        description="The chunk size for fetching against the backend.",
+    )
     mailpit_api_url: str = Field(
         "localhost:8025",
         description="The url to the api endpoint for mailpit. USED FOR TESTS ONLY!",

--- a/mex/extractors/consent_mailer/settings.py
+++ b/mex/extractors/consent_mailer/settings.py
@@ -7,6 +7,7 @@ from mex.common.types import AssetsPath
 class ConsentMailerSettings(BaseModel):
     """Settings definition class for the consent mailer."""
 
+    request_filter_chunck_size: int = 1
     mailpit_api_url: str = Field(
         "localhost:8025",
         description="The url to the api endpoint for mailpit. USED FOR TESTS ONLY!",

--- a/mex/extractors/endnote/settings.py
+++ b/mex/extractors/endnote/settings.py
@@ -15,4 +15,6 @@ class EndnoteSettings(BaseModel):
         ),
     )
 
-    cutoff_number_authors: int = 42
+    cutoff_number_authors: int = Field(
+        42, description="maximum number of authors to extract per publication"
+    )

--- a/tests/consent_mailer/conftest.py
+++ b/tests/consent_mailer/conftest.py
@@ -48,7 +48,16 @@ def mocked_consent_backend_api_connector(
     call_counter = {"count": 0}
 
     class FakeConnector:
-        def fetch_all_merged_items(
+    ...
+    ) -> Generator[AnyMergedModel, None, None]:
+        call_counter["count"] += 1
+        if (
+            entity_type
+            and "MergedPerson" in entity_type
+            and reference_field == "hadPrimarySource"
+        ):
+        ...
+    ...
             self,
             _: str | None = None,
             __: str | None = None,

--- a/tests/consent_mailer/conftest.py
+++ b/tests/consent_mailer/conftest.py
@@ -48,16 +48,7 @@ def mocked_consent_backend_api_connector(
     call_counter = {"count": 0}
 
     class FakeConnector:
-    ...
-    ) -> Generator[AnyMergedModel, None, None]:
-        call_counter["count"] += 1
-        if (
-            entity_type
-            and "MergedPerson" in entity_type
-            and reference_field == "hadPrimarySource"
-        ):
-        ...
-    ...
+        def fetch_all_merged_items(
             self,
             _: str | None = None,
             __: str | None = None,
@@ -65,12 +56,12 @@ def mocked_consent_backend_api_connector(
             referenced_identifier: list[str] | None = None,
             reference_field: str | None = None,
         ) -> Generator[AnyMergedModel, None, None]:
+            call_counter["count"] += 1
             if (
                 entity_type
                 and "MergedPerson" in entity_type
                 and reference_field == "hadPrimarySource"
             ):
-                call_counter["count"] += 1
                 return (x for x in person_store)
 
             if (
@@ -85,11 +76,9 @@ def mocked_consent_backend_api_connector(
                         consent_store,
                     )
                 )
-                call_counter["count"] += 1
                 return (x for x in consents)
 
             empty: list[AnyMergedModel] = []
-            call_counter["count"] += 1
             return (x for x in empty)
 
     monkeypatch.setattr(connector.BackendApiConnector, "get", lambda: FakeConnector())

--- a/tests/consent_mailer/test_extract.py
+++ b/tests/consent_mailer/test_extract.py
@@ -17,8 +17,11 @@ def test_extract_ldap_persons(
 
 
 @pytest.mark.usefixtures("mocked_consent_backend_api_connector")
-def test_extract_consents_for_persons() -> None:
-    # due to its mocked, we dont need any param
+def test_extract_consents_for_persons(
+    mocked_consent_backend_api_connector: dict[str, int],
+) -> None:
     persons = extract_ldap_persons(MergedPrimarySourceIdentifier(""))
     consents = extract_consents_for_persons(persons)
     assert len(consents) == 1
+    # assert 3 calls: 1 for persons, 2 for consents (2 consents in batches of size 1)
+    assert mocked_consent_backend_api_connector["count"] == 3

--- a/tests/consent_mailer/test_extract.py
+++ b/tests/consent_mailer/test_extract.py
@@ -23,5 +23,6 @@ def test_extract_consents_for_persons(
     persons = extract_ldap_persons(MergedPrimarySourceIdentifier(""))
     consents = extract_consents_for_persons(persons)
     assert len(consents) == 1
-    # assert 3 calls: 1 for persons, 2 for consents (2 consents in batches of size 1)
+    # assert 3 calls: 1 call for 2 persons, 2 calls for consent (filter for
+    # 2 persons in batches of size 1)
     assert mocked_consent_backend_api_connector["count"] == 3


### PR DESCRIPTION
### Fixed
- consent-mailer: fetch consent from DB in batches, to fix "URL too long" error


