### PR TITLE
Bump cookiecutter template to 3c389d

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "a287d7c8a604fa376f3986b0dbcb53d6354c68fe",
+  "commit": "3c389d7e70f3d3146de3a31c7f94a901184f45b8",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",
       "short_summary": "ETL pipelines for the RKI Metadata Exchange.",
       "long_summary": "The `mex-extractors` package implements a variety of ETL pipelines to **extract** metadata from primary data sources using a range of different technologies and protocols. Then, we **transform** the metadata into a standardized format using models provided by `mex-common`. The last step in this process is to **load** the harmonized metadata into a sink (file output, API upload, etc).",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "a287d7c8a604fa376f3986b0dbcb53d6354c68fe"
+      "_commit": "3c389d7e70f3d3146de3a31c7f94a901184f45b8"
     }
   },
   "directory": null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changes
+- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/3c389d
 
 ### Deprecated
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cruft==2.16.0
-mex-release==0.3.4
-pdm==2.25.9
+mex-release==0.3.5
+pdm==2.26.0
 pre-commit==4.3.0
+hishel<1


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/3c389d
