### PR TITLE
Bump cookiecutter template to 6009e2

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "3c389d7e70f3d3146de3a31c7f94a901184f45b8",
+  "commit": "6009e248d0af40a236c73776716f077c9a9cc313",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",
       "short_summary": "ETL pipelines for the RKI Metadata Exchange.",
       "long_summary": "The `mex-extractors` package implements a variety of ETL pipelines to **extract** metadata from primary data sources using a range of different technologies and protocols. Then, we **transform** the metadata into a standardized format using models provided by `mex-common`. The last step in this process is to **load** the harmonized metadata into a sink (file output, API upload, etc).",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "3c389d7e70f3d3146de3a31c7f94a901184f45b8"
+      "_commit": "6009e248d0af40a236c73776716f077c9a9cc313"
     }
   },
   "directory": null,

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -71,7 +71,7 @@ jobs:
           severity: 'MEDIUM,HIGH,CRITICAL'
 
       - name: Publish results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changes
+- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/6009e2
 
 ### Deprecated
 


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/6009e2
