### PR TITLE
feature/mx-2108_adapt_Zenodo_API_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - replace `@watch` decorator with `watch_progress` function calls across all extractors
 - replace generator functions with list-returning functions for dagster compatibility
 - open-data: only get FG, not department unit (or 'least' unit) for resource unitInCharge
+- open-data: update max number of items per page (25) in Zenodo API request
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
 - organigram: fix "parentDepartment" typo in organizational_units.json
 - open-data: fix typo in asset naming
 - organigram: testing of cached helper function

--- a/mex/extractors/open_data/connector.py
+++ b/mex/extractors/open_data/connector.py
@@ -57,7 +57,7 @@ class OpenDataConnector(HTTPConnector):
             "total"
         ]
 
-        limit = 100
+        limit = 25
         amount_pages = math.ceil(total_records / limit)
 
         return [

--- a/tests/open_data/mocked_open_data.py
+++ b/tests/open_data/mocked_open_data.py
@@ -54,7 +54,7 @@ def create_mocked_parent_response() -> dict[str, Any]:
                     "files": [],
                 },
             ],
-            "total": 200,
+            "total": 42,
         }
     }
 

--- a/tests/open_data/test_connector.py
+++ b/tests/open_data/test_connector.py
@@ -41,7 +41,7 @@ def test_get_parent_resources(mocked_open_data_connector: OpenDataConnector) -> 
 
     assert (
         mocked_open_data_connector.request.call_count == 4
-    )  # 1x connector initializing, 1x getting total, 2x for 2 pages
+    )  # 1x connector initializing, 1x getting total, 2x for 2 pages (1-25, 26-42)
     assert results == 2 * [
         OpenDataParentResource.model_validate(dummy_parents["hits"]["hits"][0]),
         OpenDataParentResource.model_validate(dummy_parents["hits"]["hits"][1]),


### PR DESCRIPTION
### PR Context
Zenodo reduced the maximum number of items per page to 25 (from 100)

### Changes
-  update max number of requested items per page, adapt tests

