### PR TITLE
feature/Pin Mailpit Docker image version to v1.28

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 10
     services:
       mailpit:
-        image: axllent/mailpit
+        image: axllent/mailpit:v1.28
         ports:
           - 1025:1025
           - 8025:8025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- Pin Mailpit Docker image version to v1.28
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
### PR Context
- we strive for explicit version management

### Changes
- Pin Mailpit Docker image version to v1.28
