### PR TITLE
Feature/mx 2145 fix transformation grippeweb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- grippeweb: clean up obsolete wasGeneratedBy transformation (mapping was removed)
+
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+### Removed
+
 - grippeweb: clean up obsolete wasGeneratedBy transformation (mapping was removed)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - grippeweb: clean up obsolete wasGeneratedBy transformation (mapping was removed)
 
-### Removed
-
 ### Fixed
 
 ### Security

--- a/mex/extractors/grippeweb/transform.py
+++ b/mex/extractors/grippeweb/transform.py
@@ -157,13 +157,6 @@ def transform_grippeweb_resource_mappings_to_dict(
         unit_in_charge = get_unit_merged_id_by_synonym(
             resource.unitInCharge[0].mappingRules[0].forValues[0]  # type: ignore[index]
         )
-        # wasGeneratedField was removed for one resource mapping, but kept for the other
-        # only look this field up if it exists in mapping
-        was_generated_by = None
-        if wgb := resource.wasGeneratedBy:
-            was_generated_by = get_unit_merged_id_by_synonym(
-                wgb[0].mappingRules[0].forValues[0]  # type: ignore[index]
-            )
         resource_dict[identifier_in_primary_source] = ExtractedResource(
             hasLegalBasis=has_legal_basis,
             hasPersonalData=has_personal_data,
@@ -200,7 +193,6 @@ def transform_grippeweb_resource_mappings_to_dict(
             theme=theme,
             title=title,
             unitInCharge=unit_in_charge,
-            wasGeneratedBy=was_generated_by,
         )
     return resource_dict["grippeweb"], resource_dict["grippeweb-plus"]
 

--- a/tests/open_data/test_transform.py
+++ b/tests/open_data/test_transform.py
@@ -190,7 +190,7 @@ def test_transform_open_data_distributions(
     }
 
 
-@pytest.mark.usefixtures("mocked_ldap", "mocked_open_data")
+@pytest.mark.usefixtures("mocked_ldap", "mocked_open_data", "mocked_wikidata")
 def test_transform_open_data_parent_resource_to_mex_resource(  # noqa: PLR0913
     mocked_open_data_parent_resource: list[OpenDataParentResource],
     mocked_open_data_persons: list[ExtractedPerson],


### PR DESCRIPTION
### Removed
- grippeweb: clean up obsolete wasGeneratedBy transformation (mapping was removed)

