### PR TITLE
Bump cookiecutter template to 33ca3a

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "ad26e4d983b65dd74f37631a9c0b22a1a601fc3f",
+  "commit": "33ca3a9c40a0fd75a6b82f3ce029d831a4dcd9b9",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",
       "short_summary": "ETL pipelines for the RKI Metadata Exchange.",
       "long_summary": "The `mex-extractors` package implements a variety of ETL pipelines to **extract** metadata from primary data sources using a range of different technologies and protocols. Then, we **transform** the metadata into a standardized format using models provided by `mex-common`. The last step in this process is to **load** the harmonized metadata into a sink (file output, API upload, etc).",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "ad26e4d983b65dd74f37631a9c0b22a1a601fc3f"
+      "_commit": "33ca3a9c40a0fd75a6b82f3ce029d831a4dcd9b9"
     }
   },
   "directory": null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/33ca3a
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/ad26e4
 
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/203934

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
-mex-release==1.2.0
-uv==0.9.25
+mex-release==1.2.1
+uv==0.9.26
 pre-commit==4.5.1


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/33ca3a
