### PR TITLE
Bump cookiecutter template to 81bc5b

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "33ca3a9c40a0fd75a6b82f3ce029d831a4dcd9b9",
+  "commit": "81bc5b7c81ecd28ca69396d5bfcb3e72daffe968",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",
       "short_summary": "ETL pipelines for the RKI Metadata Exchange.",
       "long_summary": "The `mex-extractors` package implements a variety of ETL pipelines to **extract** metadata from primary data sources using a range of different technologies and protocols. Then, we **transform** the metadata into a standardized format using models provided by `mex-common`. The last step in this process is to **load** the harmonized metadata into a sink (file output, API upload, etc).",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "33ca3a9c40a0fd75a6b82f3ce029d831a4dcd9b9"
+      "_commit": "81bc5b7c81ecd28ca69396d5bfcb3e72daffe968"
     }
   },
   "directory": null,

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v44.2.4
+        uses: renovatebot/github-action@v44.2.6
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-extractors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/81bc5b
+
 ### Deprecated
 
 ### Removed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.2.1
-uv==0.9.26
+uv==0.9.27
 pre-commit==4.5.1


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/81bc5b

### Conflicts

```diff
diff a/compose.yaml b/compose.yaml	(rejected hunks)
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   mex-extractors:
     build:
```
