### PR TITLE
feature/mx-2166-setup-dev-s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- add setting to not verify s3 ssl certificate
+- add setting for controlling s3 ssl certificate verification
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- add setting to not verify s3 ssl certificate
+
 ### Changes
 
 ### Deprecated

--- a/mex/extractors/settings.py
+++ b/mex/extractors/settings.py
@@ -108,8 +108,13 @@ class Settings(BaseSettings):
         "s3_bucket",
         description="The S3 bucket where to store objects.",
     )
-    s3_verify_ssl_certificate: bool = Field(
-        default=True, description="Whether to verify the certificate of the S3 server."
+    s3_ssl_verify: bool | AssetsPath = Field(
+        default=True,
+        description=(
+            "Either a boolean that controls whether we verify the server's TLS "
+            "certificate, or a path to a CA bundle to use. If a path is given, it can "
+            "be either absolute or relative to the `assets_dir`. Defaults to True."
+        ),
     )
     biospecimen: BiospecimenSettings = BiospecimenSettings()
     blueant: BlueAntSettings = BlueAntSettings()

--- a/mex/extractors/settings.py
+++ b/mex/extractors/settings.py
@@ -108,6 +108,9 @@ class Settings(BaseSettings):
         "s3_bucket",
         description="The S3 bucket where to store objects.",
     )
+    s3_verify_ssl_certificate: bool = Field(
+        default=True, description="Whether to verify the certificate of the S3 server."
+    )
     biospecimen: BiospecimenSettings = BiospecimenSettings()
     blueant: BlueAntSettings = BlueAntSettings()
     confluence_vvt: ConfluenceVvtSettings = ConfluenceVvtSettings()

--- a/mex/extractors/sinks/s3.py
+++ b/mex/extractors/sinks/s3.py
@@ -30,7 +30,7 @@ class S3BaseSink(BaseSink):
             endpoint_url=str(settings.s3_endpoint_url),
             aws_access_key_id=settings.s3_access_key_id.get_secret_value(),
             aws_secret_access_key=settings.s3_secret_access_key.get_secret_value(),
-            verify=settings.s3_verify_ssl_certificate,
+            verify=settings.s3_ssl_verify,
         )
 
     def close(self) -> None:

--- a/mex/extractors/sinks/s3.py
+++ b/mex/extractors/sinks/s3.py
@@ -30,6 +30,7 @@ class S3BaseSink(BaseSink):
             endpoint_url=str(settings.s3_endpoint_url),
             aws_access_key_id=settings.s3_access_key_id.get_secret_value(),
             aws_secret_access_key=settings.s3_secret_access_key.get_secret_value(),
+            verify=settings.s3_verify_ssl_certificate,
         )
 
     def close(self) -> None:


### PR DESCRIPTION
### PR Context
preparation for use of own s3 store in dev environment. we need to tell the s3 client (boto3) to trust our self-signed cert from our s3 store.

### Added

- add setting to control ssl verification for s3 sink