### PR TITLE
Bump cookiecutter template to 808f49

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "172aac4cddf8ce8f9c90d2490af8284d5b994d01",
+  "commit": "808f4937884fc1c1d3efda9f09e81bc585d4ef96",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",
       "short_summary": "ETL pipelines for the RKI Metadata Exchange.",
       "long_summary": "The `mex-extractors` package implements a variety of ETL pipelines to **extract** metadata from primary data sources using a range of different technologies and protocols. Then, we **transform** the metadata into a standardized format using models provided by `mex-common`. The last step in this process is to **load** the harmonized metadata into a sink (file output, API upload, etc).",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "172aac4cddf8ce8f9c90d2490af8284d5b994d01"
+      "_commit": "808f4937884fc1c1d3efda9f09e81bc585d4ef96"
     }
   },
   "directory": null,

--- a/.github/workflows/changelog-checking.yml
+++ b/.github/workflows/changelog-checking.yml
@@ -2,6 +2,9 @@ name: Check changelog
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,10 +14,13 @@ jobs:
   check-changelog:
     name: Check changelog
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -18,20 +18,25 @@ env:
   PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
   PY_COLORS: "1"
+  MEX_BOT_EMAIL: mex@rki.de
+  MEX_BOT_USER: RKIMetadataExchange
 
 jobs:
   cruft:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Cache requirements
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -41,7 +46,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 
@@ -50,17 +55,14 @@ jobs:
 
       - name: Configure git
         env:
-          MEX_BOT_EMAIL: ${{ vars.MEX_BOT_EMAIL }}
-          MEX_BOT_USER: ${{ vars.MEX_BOT_USER }}
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_PUB: ${{ secrets.SIGNING_PUB }}
+          SIGNING_KEY: ${{ secrets.MEX_SIGNING_KEY }}
+          SIGNING_PUB: ${{ vars.MEX_SIGNING_PUB }}
         run: |
           eval "$(ssh-agent -s)"
           mex setup-commit-signing
 
-      - name: Update template
-        env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+      - name: Update template and commit
+        id: update
         run: |
           if cruft check; then
             echo template is up to date
@@ -72,6 +74,7 @@ jobs:
           fi
           template_url=$(python -c "print(__import__('json').load(open('.cruft.json'))['template'])")
           template_ref=$(git ls-remote ${template_url} --heads main --exit-code | cut -c -6)
+          echo "template_ref=${template_ref}" >> "$GITHUB_OUTPUT"
           git checkout main
           git checkout -b cruft/cookiecutter-template-${template_ref}
           cruft update --skip-apply-ask
@@ -87,5 +90,24 @@ jobs:
           done
           git add --all --verbose
           git commit --message "Bump cookiecutter template to $template_ref" --verbose
+
+      - name: Push branch
+        if: steps.update.outputs.template_ref
+        env:
+          GH_TOKEN: ${{ secrets.MEX_CONTENT_WRITE_TOKEN }}
+          template_ref: ${{ steps.update.outputs.template_ref }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push --set-upstream origin cruft/cookiecutter-template-${template_ref} --force --verbose
-          gh pr create --title "Bump cookiecutter template to $template_ref" --body-file .cruft-pr-body --label cruft --assignee ${{ vars.MEX_BOT_USER }}
+
+      - name: Create pull request
+        if: steps.update.outputs.template_ref
+        env:
+          GH_TOKEN: ${{ secrets.MEX_PULL_REQUEST_WRITE_TOKEN }}
+          template_ref: ${{ steps.update.outputs.template_ref }}
+        run: |
+          gh pr create \
+          --title "Bump cookiecutter template to ${template_ref}" \
+          --body-file .cruft-pr-body \
+          --label cruft \
+          --assignee ${MEX_BOT_USER}

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -21,14 +21,18 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -38,7 +42,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-environment
         with:
@@ -48,7 +52,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 
@@ -71,7 +75,7 @@ jobs:
           severity: 'MEDIUM,HIGH,CRITICAL'
 
       - name: Publish results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,10 +1,8 @@
 name: Documentation
 
 on:
-  workflow_run:
-    workflows: [Release]
-    types:
-      - completed
+  push:
+    tags: ["**"]
   workflow_dispatch:
 
 env:
@@ -14,11 +12,6 @@ env:
   PIP_PREFER_BINARY: on
   PY_COLORS: "1"
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -27,14 +20,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -44,7 +40,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-environment
         with:
@@ -54,12 +50,12 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 
       - name: Setup pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Install requirements
         run: make install
@@ -68,7 +64,7 @@ jobs:
         run: make docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./docs/dist
 
@@ -78,7 +74,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
+
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -43,7 +43,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-environment
         with:
@@ -53,7 +53,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,4 +1,4 @@
-name: OpenCoDE
+name: Opencode
 
 on:
   push:
@@ -12,16 +12,20 @@ concurrency:
 
 jobs:
   sync:
+    if: github.repository_owner == 'robert-koch-institut'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: 'main'
           fetch-depth: 0
       - name: Push main branch
         run: |
-          git remote add opencode https://${{ secrets.OPENCODE_USER }}:${{ secrets.OPENCODE_TOKEN }}@gitlab.opencode.de/robert-koch-institut/mex/mex-extractors.git
+          git remote add opencode https://RKIMetadataExchange:${{ secrets.MEX_OPENCODE_TOKEN }}@gitlab.opencode.de/robert-koch-institut/mex/mex-extractors.git
           git push opencode -f
           git push opencode -f --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,8 @@ env:
   PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
   PY_COLORS: "1"
-
-permissions:
-  contents: write
-  packages: write
+  MEX_BOT_EMAIL: mex@rki.de
+  MEX_BOT_USER: RKIMetadataExchange
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,17 +31,19 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     outputs:
       tag: ${{ steps.release.outputs.tag }}
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
-          token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Cache requirements
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -53,7 +53,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 
@@ -62,17 +62,18 @@ jobs:
 
       - name: Configure git
         env:
-          MEX_BOT_EMAIL: ${{ vars.MEX_BOT_EMAIL }}
-          MEX_BOT_USER: ${{ vars.MEX_BOT_USER }}
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_PUB: ${{ secrets.SIGNING_PUB }}
+          SIGNING_KEY: ${{ secrets.MEX_SIGNING_KEY }}
+          SIGNING_PUB: ${{ vars.MEX_SIGNING_PUB }}
         run: |
           eval "$(ssh-agent -s)"
           mex setup-commit-signing
 
       - name: Release new version
         id: release
+        env:
+          GH_TOKEN: ${{ secrets.MEX_CONTENT_WRITE_TOKEN }}
         run: |
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           mex release ${{ inputs.version }}
           echo "tag=$(git describe --abbrev=0 --tags)" >> "$GITHUB_OUTPUT"
 
@@ -107,16 +108,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: release
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           ref: ${{ needs.release.outputs.tag }}
           persist-credentials: false
 
       - name: Cache requirements
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -126,7 +131,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 
@@ -135,9 +140,10 @@ jobs:
 
       - name: Build wheel and sdist distros and create a github release
         env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ needs.release.outputs.tag }} --generate-notes --latest --verify-tag
+          gh release create ${{ needs.release.outputs.tag }} \
+          --generate-notes --latest --verify-tag
           uv build --out-dir dist
           for filename in dist/*; do
             gh release upload ${{ needs.release.outputs.tag }} ${filename};

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -15,17 +15,19 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v46.1.5
+        uses: renovatebot/github-action@68a3ea99af6ad249940b5a9fdf44fc6d7f14378b # v46.1.6
         env:
-          RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          RENOVATE_REPOSITORIES: "robert-koch-institut/mex-extractors"
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
         with:
           configurationFile: renovate.json
-          token: ${{ secrets.WORKFLOW_TOKEN }}
+          token: ${{ secrets.MEX_RENOVATE_TOKEN }}

--- a/.github/workflows/reviewing.yml
+++ b/.github/workflows/reviewing.yml
@@ -14,23 +14,33 @@ jobs:
   assignee:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
-      - name: Add assignee
+      - name: Resolve assignee
+        id: resolve
         env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           user_name="${{ github.event.pull_request.user.login }}"
           user_type=$(gh api "users/${user_name}" --jq ".type")
           echo $user_name is a $user_type
           if [[ "$user_type" != "User" ]]; then
-            user_name="${{ vars.MEX_BOT_USER }}"
+            user_name="RKIMetadataExchange"
             echo using $user_name instead
           fi
-          if [[ -z "${{ github.event.pull_request.assignee.login }}" ]]; then
-            gh pr edit ${{ github.event.pull_request.html_url }} --add-assignee "${user_name}"
-          fi
+          echo "user_name=${user_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Add assignee
+        if: ${{ !github.event.pull_request.assignee.login }}
+        env:
+          GH_TOKEN: ${{ secrets.MEX_PULL_REQUEST_WRITE_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.html_url }} \
+          --add-assignee "${{ steps.resolve.outputs.user_name }}"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,7 +46,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-environment
         with:
@@ -56,7 +56,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/808f49
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/172aac
 
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/491e2d

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,13 @@
             "minimumReleaseAgeBehaviour": "timestamp-optional"
         },
         {
+            "description": "Pin GitHub Actions to SHA digests for supply chain security",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "pinDigests": true
+        },
+        {
             "description": "Immediately apply updates of mex packages",
             "matchPackageNames": [
                 "mex-*"
@@ -38,6 +45,7 @@
             "minimumReleaseAge": "0 days"
         }
     ],
+    "platformCommit": "enabled",
     "prFooter": "",
     "vulnerabilityAlerts": {
         "enabled": true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.3.0
-uv==0.10.11
+uv==0.10.12
 pre-commit==4.5.1


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/808f49

### Conflicts

```diff
diff a/.github/workflows/linting.yml b/.github/workflows/linting.yml	(rejected hunks)
@@ -29,14 +29,17 @@ jobs:
       matrix:
         python-version: [ 3.11, 3.12, 3.13, 3.14 ]
     timeout-minutes: 10
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
```

```diff
diff a/.github/workflows/testing.yml b/.github/workflows/testing.yml	(rejected hunks)
@@ -25,18 +25,21 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: [ 3.11, 3.12, 3.13, 3.14 ]
     timeout-minutes: 10
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
```

```diff
diff a/.github/workflows/cve-scan.yml b/.github/workflows/cve-scan.yml	(rejected hunks)
@@ -61,7 +65,7 @@ jobs:
           uv export --no-hashes --format requirements-txt --output-file uv/requirements.txt
 
       - name: Run trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           format: 'sarif'
           list-all-pkgs: 'true'
```

```diff
diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -111,34 +116,40 @@ jobs:
           uv export --no-dev --output locked-requirements.txt --no-hashes
 
       - name: Login to container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build, tag and push docker image
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}
+          TAG: ${{ needs.release.outputs.tag }}
         run: |
           docker build . \
-          --tag ghcr.io/robert-koch-institut/mex-extractors:latest \
-          --tag ghcr.io/robert-koch-institut/mex-extractors:${{ github.sha }} \
-          --tag ghcr.io/robert-koch-institut/mex-extractors:${{ needs.release.outputs.tag }}
-          docker push --all-tags ghcr.io/robert-koch-institut/mex-extractors
+          --tag ${IMAGE}:latest \
+          --tag ${IMAGE}:${{ github.sha }} \
+          --tag ${IMAGE}:${TAG}
+          docker push --all-tags ${IMAGE}
 
   distribute:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: release
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           ref: ${{ needs.release.outputs.tag }}
           persist-credentials: false
 
       - name: Cache requirements
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -148,7 +159,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 
```
