### PR TITLE
Bump cookiecutter template to 57105a

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "dd987e6cc7f1bcb7298b4e7aecd5055de15458bb",
+  "commit": "57105a14fe4ad7aff83c0b10d523bb19fe1f4bdd",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",
       "short_summary": "ETL pipelines for the RKI Metadata Exchange.",
       "long_summary": "The `mex-extractors` package implements a variety of ETL pipelines to **extract** metadata from primary data sources using a range of different technologies and protocols. Then, we **transform** the metadata into a standardized format using models provided by `mex-common`. The last step in this process is to **load** the harmonized metadata into a sink (file output, API upload, etc).",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "dd987e6cc7f1bcb7298b4e7aecd5055de15458bb"
+      "_commit": "57105a14fe4ad7aff83c0b10d523bb19fe1f4bdd"
     }
   },
   "directory": null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/57105a
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/dd987e
 - update lock file(2026-05-12)
 


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/57105a

### Conflicts

```diff
diff a/.github/workflows/testing.yml b/.github/workflows/testing.yml	(rejected hunks)
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-requirements
         with:
```

```diff
diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.3.3
-uv==0.11.8
+uv==0.11.15
 pre-commit==4.6.0
```
