### PR TITLE
Bump cookiecutter template to 11612b

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "52887e07dbc2501edea124e2a27a4f472f970d7e",
+  "commit": "11612bf1151a5d537ecf660e70135c2e9f79d350",
   "context": {
     "cookiecutter": {
       "project_name": "extractors",
       "short_summary": "ETL pipelines for the RKI Metadata Exchange.",
       "long_summary": "The `mex-extractors` package implements a variety of ETL pipelines to **extract** metadata from primary data sources using a range of different technologies and protocols. Then, we **transform** the metadata into a standardized format using models provided by `mex-common`. The last step in this process is to **load** the harmonized metadata into a sink (file output, API upload, etc).",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "52887e07dbc2501edea124e2a27a4f472f970d7e"
+      "_commit": "11612bf1151a5d537ecf660e70135c2e9f79d350"
     }
   },
   "directory": null,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,9 +111,9 @@ jobs:
         with:
           push: true
           tags: |
-            ${IMAGE}:latest
-            ${IMAGE}:${{ github.sha }}
-            ${IMAGE}:${TAG}
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:${{ env.TAG }}
           outputs: type=image,oci-mediatypes=true
 
       - name: Install cosign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/11612b
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/52887e
 
 - use ldap convenience function and refactor ldap and organigram helper functions

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ components of the MEx project are open-sourced under the same license as well.
 Images released to GHCR are signed using [cosign](https://github.com/sigstore/cosign).
 
 To verify an image manually:
-`cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/extractors" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/extractors:<tag>`
+`cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/mex-extractors/.github/workflows/release.yml@refs/heads/main" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/mex-extractors:<tag>`
 
 ## Commands
 


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/11612b
