### PR TITLE
Feature/hotfix pin postgres version to 16.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- pin postgres version to 16.13 for now.
+
 ### Security
 
 ## [1.17.0] - 2026-07-29

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16.13-trixie # PINNED! Newer versions are incompatible. See MX-2398
+    image: postgres:16.13-trixie # PINNED! Do not update outside MX-2398
     environment:
       POSTGRES_USER: dagster
       POSTGRES_PASSWORD: dagster

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:18.4-trixie
+    image: postgres:16.13-trixie # PINNED! Newer versions are incompatible. See MX-2398
     environment:
       POSTGRES_USER: dagster
       POSTGRES_PASSWORD: dagster


### PR DESCRIPTION
### Fixed

- pin postgres version to 16.13 for now.
