### PR TITLE
feature/mx-1142-test-backend-integration

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -84,6 +84,10 @@ jobs:
           MEX_BACKEND_API_KEY: write_key
         run: make test
 
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose logs mex-backend neo4j
+
       - name: Cleanup containers
         if: always()
         run: docker compose down slapd mailpit neo4j mex-backend

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 1
 
       - name: Start containers
-        run: docker compose up -d slapd mailpit
+        run: docker compose up -d slapd mailpit neo4j mex-backend
 
       - name: Cache requirements
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -68,12 +68,22 @@ jobs:
           echo ${{ matrix.python-version }} > .python-version
           make install
 
+      - name: Wait for mex-backend readiness
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8080/v0/_system/check && exit 0
+            sleep 2
+          done
+          echo "mex-backend did not become ready in time" >&2
+          exit 1
+
       - name: Run test suite
         env:
           MEX_LDAP_URL: ldap://cn=admin,dc=ldapmock,dc=local:adminpass@localhost:636
-#          MEX_LDAP_SEARCH_BASE: dc=ldapmock,dc=local
+          MEX_BACKEND_API_URL: http://localhost:8080/
+          MEX_BACKEND_API_KEY: write_key
         run: make test
 
       - name: Cleanup containers
         if: always()
-        run: docker compose down slapd mailpit
+        run: docker compose down slapd mailpit neo4j mex-backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Added
 
-- tests: integration tests with mex-backend. Setup: start neo4j and testing-backend with MEX_DEBUG=True
+- tests: integration tests with mex-backend in CI. Skipped locally to avoid manual
+  backend setup, will be automated in MX-1523.
 
 ### Changes
 
@@ -41,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--  patch dependency to mex-common 3.1.1 and update resources to fixed start and end type.
+- patch dependency to mex-common 3.1.1 and update resources to fixed start and end type.
 
 ## [1.16.0] - 2026-07-20
 
@@ -88,11 +89,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/0d8c47
 - use ldap convenience function and refactor ldap and organigram helper functions
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/1d816d
-- dependency update(2026-06-16)
+- dependency update (2026-06-16)
 - implement seq-repo fallback rule for units
 
 ### Removed
-- dependency update(2026-06-26)
+
+- dependency update (2026-06-26)
 
 ### Fixed
 
@@ -169,7 +171,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- path to s3 items file is now `publisher-{mex-model major version}.{mex-model minor version}/items.ndjson`
+- path to s3 items file is now
+  `publisher-{mex-model major version}.{mex-model minor version}/items.ndjson`
 - update mex-common to 1.16.1
 
 ## [1.11.0] - 2026-03-13
@@ -201,7 +204,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- ff-projects: fixed extract_ff_projects_organizations() and get_or_create_organization() to match organizations with wikidata
+- ff-projects: fixed extract_ff_projects_organizations () and get_or_create_organization
+  () to match organizations with wikidata
 
 ## [1.9.0] - 2026-02-10
 
@@ -318,12 +322,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/a67c71
-- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/6009e2
+- bumped cookiecutter template
+  to https://github.com/robert-koch-institut/mex-template/commit/a67c71
+- bumped cookiecutter template
+  to https://github.com/robert-koch-institut/mex-template/commit/6009e2
 - replace `@watch` decorator with `watch_progress` function calls across all extractors
 - replace generator functions with list-returning functions for dagster compatibility
 - update extractors to handle multiple organizational units per synonym mapping
-- open-data: only get FG, not department unit (or 'least' unit) for resource unitInCharge
+- open-data: only get FG, not department unit (or 'least' unit) for resource
+  unitInCharge
 - open-data: update max number of items per page (25) in Zenodo API request
 
 ### Fixed
@@ -342,7 +349,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/3c389d
+- bumped cookiecutter template
+  to https://github.com/robert-koch-institut/mex-template/commit/3c389d
 - implement igs resource mapping update
 
 ## [1.4.0] - 2025-10-28
@@ -373,8 +381,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - optional value fields for igs access platform and resource
 - update mex-common dependency to 1.5
 - persons have rki org as affiliation
-- create s3 sink base class and bequeath to s3Sink (writes ndjson) and new S3XlsxSink (writs xlsx)
-- publisher: replace references to non-consenting person ids with their respective unit ids
+- create s3 sink base class and bequeath to s3Sink (writes ndjson) and new S3XlsxSink
+  (writs xlsx)
+- publisher: replace references to non-consenting person ids with their respective unit
+  ids
 
 ### Changes
 
@@ -420,20 +430,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `AssetCheckRule` model into `mex.extractors.pipeline.checks.models.check`
-- assetcheck implementation for `x_items_more_than`-rule in `mex.extractors.pipeline.checks.main`
-- AssetChecks `x_items_more_than` for blueant `mex.extractors.blueant.checks` and endnote `mex.extractors.endnote.checks`
+- assetcheck implementation for `x_items_more_than`-rule in
+  `mex.extractors.pipeline.checks.main`
+- AssetChecks `x_items_more_than` for blueant `mex.extractors.blueant.checks` and
+  endnote `mex.extractors.endnote.checks`
 - tests for blueant, endnote and pipeline
 - yaml rule data for testing `assets\raw-data\pipeline\{extractor}\{entityType}`
 - `all_checks_path` added in `mex.extractors.settings` for rules
 - finished consent-mailer pipeline
 - settings for the content-mailer
-  - smtp server address for sending mails
-  - mailHog api endpoint url for testing mail sending
+    - smtp server address for sending mails
+    - mailHog api endpoint url for testing mail sending
 - add return values to all assets for debugging and bookkeeping
 
 ### Changes
 
-- `extracted_endnote_bibliographic_resources()` and `extracted_blueant_activities()` return `Output`-object
+- `extracted_endnote_bibliographic_resources()` and `extracted_blueant_activities()`
+  return `Output`-object
 - improve usage of backend endpoints for merged items
 - add resources by unit filter to datenkompass
 - update mex-common dependency to 1.2
@@ -650,7 +663,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - split seq-repo load function into new asset
-- apply all activity filters to all extractors(except synopse) with activities
+- apply all activity filters to all extractors (except synopse) with activities
 - refactor filter functionality to filter module
 
 ### Removed
@@ -681,8 +694,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - output settings as job metadata
 - update mex-common to 0.54.3
 - expand publisher filter to not push MergedPersons
-- quickfix publisher to always write an ndjson directly to S3
-  (will become outdated by MX-1808)
+- quickfix publisher to always write an ndjson directly to S3 (will become outdated by
+  MX-1808)
 
 ## [0.29.1] - 2025-03-14
 
@@ -878,8 +891,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - combine seq-repo distribution and resource extraction in one asset
 - duplicate seq-repo activities are filtered out
-- make dependent extractors explicitly depend on each other
-  (grippeweb on confluence-vvt, biospecimen on synopse, odk on international-projects)
+- make dependent extractors explicitly depend on each other (grippeweb on
+  confluence-vvt, biospecimen on synopse, odk on international-projects)
 - add publisher pipeline to pull all merged items from backend and write them to ndjson
 - BREAKING: integrate extractor specific settings in main extractor settings class.
   Environment variables change from `EXTRACTOR_PARAMETER` to `MEX_EXTRACTOR__PARAMETER`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- tests: integration tests with mex-backend. Setup: start neo4j and testing-backend with MEX_DEBUG=True
+
 ### Changes
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- tests: make `mex.bat test` run tests marked with `requires_rki_infrastructure`
+
 ### Deprecated
 
 ### Removed

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,9 @@ unit:
 
 test:
 	# run the unit and integration test suites
+	# single worker: integration tests share one live backend/graph instance
 	@ echo running all tests; \
-	uv run pytest --numprocesses=auto --dist=worksteal -m "not requires_rki_infrastructure"; \
+	uv run pytest -m "not requires_rki_infrastructure"; \
 
 wheel:
 	# build the python package

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
   dagster-daemon:
     build:
       context: .
-    entrypoint: ["dagster-daemon", "run", "-w", "workspace.yaml"]
+    entrypoint: [ "dagster-daemon", "run", "-w", "workspace.yaml" ]
     depends_on:
       - postgres
     volumes:
@@ -21,11 +21,11 @@ services:
       context: .
     ports:
       - 3000:3000
-    entrypoint: ["dagster-webserver", "--host", "0.0.0.0", "-w", "workspace.yaml"]
+    entrypoint: [ "dagster-webserver", "--host", "0.0.0.0", "-w", "workspace.yaml" ]
     depends_on:
       - postgres
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/dagit_info"]
+      test: [ "CMD", "curl", "-f", "http://localhost:3000/dagit_info" ]
       interval: 30s
       timeout: 10s
       start_period: 60s
@@ -60,7 +60,7 @@ services:
     ports:
       - 7687:7687
     healthcheck:
-      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "password", "RETURN 1"]
+      test: [ "CMD", "cypher-shell", "-u", "neo4j", "-p", "password", "RETURN 1" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -76,6 +76,7 @@ services:
     environment:
       - MEX_GRAPH_URL=neo4j://neo4j:7687
       - MEX_BACKEND_API_KEY_DATABASE={"write":["write_key"]}
+      - MEX_DEBUG=true
     expose:
       - 8080
 volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -52,6 +52,32 @@ services:
       - MP_UI_AUTH=user:password
     expose:
       - 8025
+  neo4j:
+    image: neo4j:2026.06-community
+    environment:
+      - NEO4J_AUTH=neo4j/password
+      - NEO4J_dbms_usage__report_enabled=false
+    ports:
+      - 7687:7687
+    healthcheck:
+      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "password", "RETURN 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+  mex-backend:
+    image: ghcr.io/robert-koch-institut/mex-backend:4.2.2
+    entrypoint: testing-backend
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    ports:
+      - 8080:8080
+    environment:
+      - MEX_GRAPH_URL=neo4j://neo4j:7687
+      - MEX_BACKEND_API_KEY_DATABASE={"write":["write_key"]}
+    expose:
+      - 8080
 volumes:
   pgdata:
   dagster:

--- a/mex.bat
+++ b/mex.bat
@@ -46,7 +46,7 @@ exit /b %errorlevel%
 :test
 @REM run the unit and integration test suites
 echo running all tests
-uv run pytest --numprocesses=auto --dist=worksteal
+uv run pytest
 exit /b %errorlevel%
 
 

--- a/mex.bat
+++ b/mex.bat
@@ -46,7 +46,7 @@ exit /b %errorlevel%
 :test
 @REM run the unit and integration test suites
 echo running all tests
-uv run pytest --numprocesses=auto --dist=worksteal -m "not requires_rki_infrastructure"
+uv run pytest --numprocesses=auto --dist=worksteal
 exit /b %errorlevel%
 
 

--- a/tests/backend_api/conftest.py
+++ b/tests/backend_api/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from mex.common.backend_api.connector import BackendApiConnector
+
+
+@pytest.fixture(autouse=True)
+def isolate_backend_graph(is_integration_test: bool) -> None:  # noqa: FBT001
+    """Flush the graph database before every test, same as mex-backend's own suite."""
+    if is_integration_test:
+        BackendApiConnector.get().flush_graph()

--- a/tests/backend_api/test_backend_api.py
+++ b/tests/backend_api/test_backend_api.py
@@ -1,26 +1,30 @@
+import os
+
 import pytest
 
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.models import MEX_PRIMARY_SOURCE_STABLE_TARGET_ID, ExtractedContactPoint
 from mex.common.sinks.backend_api import BackendApiSink
 
-# force tests to run in the exact same worker process to avoid interfering effects
-pytestmark = pytest.mark.xdist_group(name="backend_api")
+IN_CI = os.environ.get("CI") == "true"
+
+pytestmark = [
+    # force tests to run in the exact same worker process to avoid interfering effects
+    pytest.mark.xdist_group(name="backend_api"),
+    # skip backend integration tests outside CI for now, to avoid manual backend setup, addressed in MX-1523
+    pytest.mark.skipif(not IN_CI, reason="Test requires CI environment"),
+]
 
 
 @pytest.mark.integration
-def test_backend_api_is_available(in_continuous_integration: bool) -> None:  # noqa: FBT001
-    if not in_continuous_integration:
-        pytest.skip("Test requires CI environment")
+def test_backend_api_is_available() -> None:
     connector = BackendApiConnector.get()  # already health-checks on construction
     status = connector.system_status()
     assert status.status == "ok"
 
 
 @pytest.mark.integration
-def test_identity_assign_is_idempotent(in_continuous_integration: bool) -> None:  # noqa: FBT001
-    if not in_continuous_integration:
-        pytest.skip("Test requires CI environment")
+def test_identity_assign_is_idempotent() -> None:
     # use the connector directly, bypassing BackendApiIdentityProvider's
     # client-side lru_cache, so both assigns actually hit the backend
     identifier_in_primary_source = "extractors-identity-roundtrip"
@@ -39,9 +43,7 @@ def test_identity_assign_is_idempotent(in_continuous_integration: bool) -> None:
 
 
 @pytest.mark.integration
-def test_ingest_roundtrip(in_continuous_integration: bool) -> None:  # noqa: FBT001
-    if not in_continuous_integration:
-        pytest.skip("Test requires CI environment")
+def test_ingest_roundtrip() -> None:
     identifier_in_primary_source = "extractors-ingest-roundtrip"
     contact_point = ExtractedContactPoint(
         hadPrimarySource=MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,

--- a/tests/backend_api/test_backend_api.py
+++ b/tests/backend_api/test_backend_api.py
@@ -4,15 +4,18 @@ from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.models import MEX_PRIMARY_SOURCE_STABLE_TARGET_ID, ExtractedContactPoint
 from mex.common.sinks.backend_api import BackendApiSink
 
-pytestmark = [pytest.mark.integration, pytest.mark.xdist_group(name="backend_api")]
+# force tests to run in the exact same worker process to avoid interfering effects
+pytestmark = pytest.mark.xdist_group(name="backend_api")
 
 
+@pytest.mark.integration
 def test_backend_api_is_available() -> None:
     connector = BackendApiConnector.get()  # already health-checks on construction
     status = connector.system_status()
     assert status.status == "ok"
 
 
+@pytest.mark.integration
 def test_identity_assign_is_idempotent() -> None:
     # use the connector directly, bypassing BackendApiIdentityProvider's
     # client-side lru_cache, so both assigns actually hit the backend
@@ -31,6 +34,7 @@ def test_identity_assign_is_idempotent() -> None:
     assert first == second
 
 
+@pytest.mark.integration
 def test_ingest_roundtrip() -> None:
     identifier_in_primary_source = "extractors-ingest-roundtrip"
     contact_point = ExtractedContactPoint(

--- a/tests/backend_api/test_backend_api.py
+++ b/tests/backend_api/test_backend_api.py
@@ -9,14 +9,18 @@ pytestmark = pytest.mark.xdist_group(name="backend_api")
 
 
 @pytest.mark.integration
-def test_backend_api_is_available() -> None:
+def test_backend_api_is_available(in_continuous_integration: bool) -> None:  # noqa: FBT001
+    if not in_continuous_integration:
+        pytest.skip("Test requires CI environment")
     connector = BackendApiConnector.get()  # already health-checks on construction
     status = connector.system_status()
     assert status.status == "ok"
 
 
 @pytest.mark.integration
-def test_identity_assign_is_idempotent() -> None:
+def test_identity_assign_is_idempotent(in_continuous_integration: bool) -> None:  # noqa: FBT001
+    if not in_continuous_integration:
+        pytest.skip("Test requires CI environment")
     # use the connector directly, bypassing BackendApiIdentityProvider's
     # client-side lru_cache, so both assigns actually hit the backend
     identifier_in_primary_source = "extractors-identity-roundtrip"
@@ -35,7 +39,9 @@ def test_identity_assign_is_idempotent() -> None:
 
 
 @pytest.mark.integration
-def test_ingest_roundtrip() -> None:
+def test_ingest_roundtrip(in_continuous_integration: bool) -> None:  # noqa: FBT001
+    if not in_continuous_integration:
+        pytest.skip("Test requires CI environment")
     identifier_in_primary_source = "extractors-ingest-roundtrip"
     contact_point = ExtractedContactPoint(
         hadPrimarySource=MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,

--- a/tests/backend_api/test_backend_api.py
+++ b/tests/backend_api/test_backend_api.py
@@ -9,8 +9,6 @@ from mex.common.sinks.backend_api import BackendApiSink
 IN_CI = os.environ.get("CI") == "true"
 
 pytestmark = [
-    # force tests to run in the exact same worker process to avoid interfering effects
-    pytest.mark.xdist_group(name="backend_api"),
     # skip backend integration tests outside CI for now, to avoid manual backend setup, addressed in MX-1523
     pytest.mark.skipif(not IN_CI, reason="Test requires CI environment"),
 ]

--- a/tests/backend_api/test_backend_api.py
+++ b/tests/backend_api/test_backend_api.py
@@ -1,0 +1,50 @@
+import pytest
+
+from mex.common.backend_api.connector import BackendApiConnector
+from mex.common.models import MEX_PRIMARY_SOURCE_STABLE_TARGET_ID, ExtractedContactPoint
+from mex.common.sinks.backend_api import BackendApiSink
+
+pytestmark = [pytest.mark.integration, pytest.mark.xdist_group(name="backend_api")]
+
+
+def test_backend_api_is_available() -> None:
+    connector = BackendApiConnector.get()  # already health-checks on construction
+    status = connector.system_status()
+    assert status.status == "ok"
+
+
+def test_identity_assign_is_idempotent() -> None:
+    # use the connector directly, bypassing BackendApiIdentityProvider's
+    # client-side lru_cache, so both assigns actually hit the backend
+    identifier_in_primary_source = "extractors-identity-roundtrip"
+    connector = BackendApiConnector.get()
+
+    first = connector.assign_identity(
+        had_primary_source=MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
+        identifier_in_primary_source=identifier_in_primary_source,
+    )
+    second = connector.assign_identity(
+        had_primary_source=MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
+        identifier_in_primary_source=identifier_in_primary_source,
+    )
+
+    assert first == second
+
+
+def test_ingest_roundtrip() -> None:
+    identifier_in_primary_source = "extractors-ingest-roundtrip"
+    contact_point = ExtractedContactPoint(
+        hadPrimarySource=MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
+        identifierInPrimarySource=identifier_in_primary_source,
+        email=["test@example.com"],
+    )
+
+    sink = BackendApiSink.get()
+    list(sink.load([contact_point]))
+
+    connector = BackendApiConnector.get()
+    result = connector.fetch_extracted_items(
+        stable_target_id=str(contact_point.stableTargetId),
+    )
+    assert result.total == 1
+    assert result.items[0].identifierInPrimarySource == identifier_in_primary_source


### PR DESCRIPTION
### Added

- tests: integration tests with mex-backend in CI. Skipped locally to avoid manual
  backend setup, will be automated in MX-1523.

### Changes

- tests: make `mex.bat test` run tests marked with `requires_rki_infrastructure`
