### PR TITLE
feature/move-parse-csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- moved mex.common.extract.parse_csv to mex.extractors.utils to rid mex-common of pandas
 - add final outbound checks for synopse and voxco
 - tests: integration tests with mex-backend in CI. Skipped locally to avoid manual
   backend setup, will be automated in MX-1523.

--- a/mex/extractors/synopse/extract.py
+++ b/mex/extractors/synopse/extract.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING
 
-from mex.common.extract import parse_csv
 from mex.common.ldap.transform import analyse_person_string
 from mex.extractors.ldap.helpers import (
     get_ldap_merged_contact_id_by_mail,
@@ -12,6 +11,7 @@ from mex.extractors.synopse.models.project import ProjektUndStudienverwaltung
 from mex.extractors.synopse.models.study import MetadatenZuDatensaetzen
 from mex.extractors.synopse.models.study_overview import Datensatzuebersicht
 from mex.extractors.synopse.models.variable import Variablenuebersicht
+from mex.extractors.utils import parse_csv
 from mex.extractors.wikidata.helpers import (
     get_wikidata_extracted_organization_id_by_name,
 )

--- a/mex/extractors/utils.py
+++ b/mex/extractors/utils.py
@@ -1,11 +1,114 @@
+from collections import defaultdict
+from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+import pandas as pd
 import yaml
+from pydantic import ValidationError
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+from mex.common.logging import logger
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Generator, Iterable, Sequence
     from os import PathLike
+
+    from pandas._typing import Dtype, ReadCsvBuffer
+
+    from mex.common.models import BaseModel
+
+
+PANDAS_DTYPE_MAP = defaultdict(
+    lambda: "string",
+    {bool: "bool", float: "Float64", int: "Int64"},
+)
+
+
+def get_dtypes_for_model(model: type[BaseModel]) -> dict[str, Dtype]:
+    """Get the basic dtypes per field for a model from the `PANDAS_DTYPE_MAP`.
+
+    Args:
+        model: Model class for which to get pandas data types per field alias
+
+    Returns:
+        Mapping from field alias to dtype strings
+    """
+    return {
+        f.alias or name: PANDAS_DTYPE_MAP[f.annotation or type(None)]
+        for name, f in model.model_fields.items()
+    }
+
+
+def parse_csv[BaseModelT: BaseModel](  # noqa: C901
+    path_or_buffer: str | PathLike[str] | ReadCsvBuffer[Any],
+    into: type[BaseModelT],
+    chunksize: int = 10000,
+    summary_batch_size: int = 10000,
+    **kwargs: Any,  # noqa: ANN401
+) -> Generator[BaseModelT]:
+    """Parse a CSV file into an iterable of the given model type.
+
+    Args:
+        path_or_buffer: Location of CSV file or read buffer with CSV content
+        into: Type of model to parse
+        chunksize: Buffer size for chunked reading
+        summary_batch_size: Batch size for summary logs
+        kwargs: Additional keywords arguments for pandas
+
+    Returns:
+        Generator for models
+    """
+    error_summary: defaultdict[str, int] = defaultdict(int)
+    total_rows_processed = 0
+    total_rows_successfully_processed = 0
+
+    with pd.read_csv(
+        path_or_buffer,
+        chunksize=chunksize,
+        dtype=get_dtypes_for_model(into),
+        **kwargs,
+    ) as reader:
+        for i, chunk in enumerate(reader):
+            logger.info(
+                "parse_csv - %s chunk %s - OK",
+                into.__name__,
+                i,
+            )
+            for _, row in chunk.iterrows():
+                row_dict = row.to_dict()
+                for k, v in row_dict.items():
+                    if pd.isna(v) or (isinstance(v, str) and not v.strip()):
+                        row_dict[k] = None
+                try:
+                    model = into.model_validate(row_dict)
+                    total_rows_successfully_processed += 1
+                    yield model
+                except ValidationError as error:
+                    for validation_error in error.errors():
+                        error_type = validation_error["type"]
+                        error_summary[error_type] += 1
+
+                total_rows_processed += 1
+
+                if total_rows_processed % summary_batch_size == 0 and error_summary:
+                    logger.error(
+                        "Summarizing errors for batch with rows %s to %s",
+                        total_rows_processed - summary_batch_size + 1,
+                        total_rows_processed,
+                    )
+                    for error_type, count in error_summary.items():
+                        logger.error(
+                            " - Error type '%s': %s occurrences", error_type, count
+                        )
+                    error_summary.clear()
+
+    if error_summary:
+        logger.error("Summarizing errors for remaining rows")
+        for error_type, count in error_summary.items():
+            logger.error(" - Error type '%s': %s occurrences", error_type, count)
+        logger.info(
+            "Successfully processed %s items.", total_rows_successfully_processed
+        )
 
 
 def load_yaml(path: PathLike[str]) -> dict[str, Any]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,123 @@
+from datetime import date  # noqa: TC003
+from io import StringIO
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
+from mex.common.extract import get_dtypes_for_model, parse_csv
+from mex.common.models import BaseModel
 from mex.extractors.utils import (
     collect_related_identifier_counts,
     collect_related_identifiers,
 )
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pytest import LogCaptureFixture
+
+
+class DummyModel(BaseModel):
+    bool_: bool
+    str_: str
+    date_: date
+    float_: float
+    int_: int
+
+
+def test_get_dtypes_for_model() -> None:
+    assert get_dtypes_for_model(DummyModel) == {
+        "bool_": "bool",
+        "str_": "string",
+        "date_": "string",
+        "float_": "Float64",
+        "int_": "Int64",
+    }
+
+
+def test_parse_csv(caplog: LogCaptureFixture) -> None:
+    buffer = StringIO(
+        """
+bool_,str_,date_,float_,int_
+true,"good row",2000-01-01,2.718,42
+false,"bad row",,,
+false,"another bad row",2000-01-01,,""
+true,"another good row",2001-02-03,3.14,42
+        """.strip()
+    )
+
+    parsed_models = list(parse_csv(buffer, DummyModel, chunksize=2))
+    assert len(parsed_models) == 2
+    assert parsed_models[0].str_ == "good row"
+    assert parsed_models[1].str_ == "another good row"
+
+    records = caplog.records
+
+    assert (
+        len(records) == 7
+    )  # 2 info logs for chunks, 1+3 error logs and 1 info log for amount processed
+
+    assert records[0].levelname == "INFO"
+    assert "parse_csv - DummyModel chunk 0 - OK" in records[0].message
+    assert records[1].levelname == "INFO"
+    assert "parse_csv - DummyModel chunk 1 - OK" in records[1].message
+
+    assert records[2].levelname == "ERROR"
+    assert "Summarizing errors for remaining rows" in records[2].message
+    assert records[3].levelname == "ERROR"
+    assert "Error type 'date_type': 1 occurrences" in records[3].message
+    assert records[4].levelname == "ERROR"
+    assert "Error type 'float_type': 2 occurrences" in records[4].message
+    assert records[5].levelname == "ERROR"
+    assert "Error type 'int_type': 2 occurrences" in records[5].message
+
+    assert records[6].levelname == "INFO"
+    assert "Successfully processed 2 items." in records[6].message
+
+
+def test_parse_csv_batch_summary(caplog: LogCaptureFixture) -> None:
+    buffer = StringIO(
+        """
+bool_,str_,date_,float_,int_
+true,"good",2000-01-01,1.0,1
+false,"bad1",,,
+false,"bad2",,,
+true,"good",2000-01-01,1.0,1
+false,"bad3",,,
+        """.strip()
+    )
+
+    parsed_models = list(parse_csv(buffer, DummyModel, summary_batch_size=3))
+    assert len(parsed_models) == 2
+    assert parsed_models[0].str_ == "good"
+    assert parsed_models[1].str_ == "good"
+
+    records = caplog.records
+
+    assert (
+        len(records) == 10
+    )  # 1 info log for chunk, 1+3+1+3 error logs for 2 batches and 1 info log for amount processed
+
+    assert records[0].levelname == "INFO"
+    assert "parse_csv - DummyModel chunk 0 - OK" in records[0].message
+
+    assert records[1].levelname == "ERROR"
+    assert "Summarizing errors for batch with rows 1 to 3" in records[1].message
+    assert records[2].levelname == "ERROR"
+    assert "Error type 'date_type': 2 occurrences" in records[2].message
+    assert records[3].levelname == "ERROR"
+    assert "Error type 'float_type': 2 occurrences" in records[3].message
+    assert records[4].levelname == "ERROR"
+    assert "Error type 'int_type': 2 occurrences" in records[4].message
+
+    assert records[5].levelname == "ERROR"
+    assert "Summarizing errors for remaining rows" in records[5].message
+    assert records[6].levelname == "ERROR"
+    assert "Error type 'date_type': 1 occurrences" in records[6].message
+    assert records[7].levelname == "ERROR"
+    assert "Error type 'float_type': 1 occurrences" in records[7].message
+    assert records[8].levelname == "ERROR"
+    assert "Error type 'int_type': 1 occurrences" in records[8].message
+
+    assert records[9].levelname == "INFO"
+    assert "Successfully processed 2 items." in records[9].message
 
 
 def test_collect_related_identifiers_keeps_duplicate_references() -> None:


### PR DESCRIPTION
### PR Context

- mex-extractors was the only consumer of `parse_csv`, so [i removed it from mex-common](https://github.com/robert-koch-institut/mex-common/pull/802)

### Added

- moved mex.common.extract.parse_csv to mex.extractors.utils to rid mex-common of pandas