### PR TITLE
feature/datenkompass-vocabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- stop using `Vocabulary.__concepts__` in datencompass for fw-compat with static enums
 - new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.5.0
 - tests: make `mex.bat test` run tests marked with `requires_rki_infrastructure`
 

--- a/mex/extractors/datenkompass/transform.py
+++ b/mex/extractors/datenkompass/transform.py
@@ -1,8 +1,7 @@
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, Final, cast
 
 from bs4 import BeautifulSoup
 
-from mex.common.types import BibliographicResourceType, Frequency, License, Theme
 from mex.extractors.datenkompass.models.item import (
     DatenkompassActivity,
     DatenkompassBibliographicResource,
@@ -11,8 +10,11 @@ from mex.extractors.datenkompass.models.item import (
 from mex.extractors.datenkompass.models.mapping import DatenkompassMapping
 from mex.extractors.settings import ExtractorsSettings
 from mex.extractors.utils import load_yaml
+from mex.model import VOCABULARY_JSON_BY_NAME
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
     from pydantic import BaseModel
 
     from mex.common.models import (
@@ -28,16 +30,16 @@ if TYPE_CHECKING:
         MergedOrganizationalUnitIdentifier,
         MergedPersonIdentifier,
         Text,
+        VocabularyEnum,
     )
     from mex.extractors.datenkompass.models.mapping import DatenkompassMappingField
 
-VocabularyT = TypeVar(
-    "VocabularyT",
-    Theme,
-    BibliographicResourceType,
-    Frequency,
-    License,
-)
+GERMAN_LABEL_BY_CONCEPT_ID: Final[dict[str, str]] = {
+    concept["identifier"]: pref_label["de"]
+    for concepts in VOCABULARY_JSON_BY_NAME.values()
+    for concept in concepts
+    if (pref_label := concept.get("prefLabel"))
+}
 
 
 def fix_quotes(string: str) -> str:
@@ -186,32 +188,22 @@ def get_title(item: MergedActivity) -> list[str]:
     return collected_titles
 
 
-def get_german_vocabulary[
-    VocabularyT: (Theme, BibliographicResourceType, Frequency, License)
-](
-    entries: list[VocabularyT] | None,
-) -> list[str | None]:
-    """Get german prefLabel for Vocabularies.
+def get_german_vocabulary(entries: Iterable[VocabularyEnum] | None) -> list[str]:
+    """Get the german prefLabels for vocabulary entries.
+
+    Entries without a german prefLabel are skipped.
 
     Args:
-        entries: list of vocabulary type entries.
+        entries: iterable of vocabulary enum entries, or None.
 
     Returns:
-        list of german Vocabulary entries as strings.
+        list of german vocabulary labels as strings.
     """
-    if entries:
-        return [
-            next(
-                (
-                    concept.prefLabel.de
-                    for concept in type(entry).__concepts__
-                    if str(concept.identifier) == entry.value
-                ),
-                None,
-            )
-            for entry in entries
-        ]
-    return []
+    return [
+        label
+        for entry in entries or []
+        if (label := GERMAN_LABEL_BY_CONCEPT_ID.get(entry.value))
+    ]
 
 
 def get_datenbank(item: MergedBibliographicResource) -> str | None:
@@ -295,7 +287,7 @@ def handle_setval(set_value: list[str] | str | None) -> str:
 
 
 def filter_schlagworte(
-    words: list[str | None],
+    words: Sequence[str],
     delim: str,
     min_word_length: int,
     max_string_length: int,
@@ -540,7 +532,7 @@ def transform_bibliographic_resources(
             creator_collection += " / et al."
         titel = f"{title_collection} ({creator_collection})"
         vocab = get_german_vocabulary(item.bibliographicResourceType)
-        beschreibung = f"{delim.join(v for v in vocab if v is not None)}. "
+        beschreibung = f"{delim.join(vocab)}. "
         beschreibung += get_abstract_or_description(item.abstract, delim)
         voraussetzungen = next(
             handle_setval(rule.setValues)
@@ -644,11 +636,11 @@ def transform_resources(
         default_by_fieldname["kommentar"].mappingRules[0].setValues
     )
 
-    result_resoures_by_primary_source_by_unit: dict[
+    result_resources_by_primary_source_by_unit: dict[
         str, dict[str, list[DatenkompassResource]]
     ] = {}
     for unit, inner_dict in merged_resources_by_primary_source_by_unit.items():
-        result_resoures_by_primary_source: dict[str, list[DatenkompassResource]] = {}
+        result_resources_by_primary_source: dict[str, list[DatenkompassResource]] = {}
         for primary_source, merged_resources_list in inner_dict.items():
             datenkompass_resources = []
             for item in merged_resources_list:
@@ -658,13 +650,13 @@ def transform_resources(
                     if rule.forValues
                     and rule.forValues[0] == item.accessRestriction.name
                 )
-                frequenz_vocabulary = (
-                    get_german_vocabulary([item.accrualPeriodicity])
-                    if item.accrualPeriodicity
-                    else []
-                )
                 frequenz = (
-                    delim.join(f for f in frequenz_vocabulary if f is not None) or None
+                    delim.join(
+                        get_german_vocabulary(
+                            [item.accrualPeriodicity] if item.accrualPeriodicity else []
+                        )
+                    )
+                    or None
                 )
                 kontakt = get_resource_email(
                     item.contact,
@@ -689,12 +681,7 @@ def transform_resources(
                     [item.license] if item.license else [],
                 )
                 rechtsgrundlagen_benennung = (
-                    delim.join(
-                        entry
-                        for entry in rechtsgrundlagen_benennung_collection
-                        if entry is not None
-                    )
-                    or None
+                    delim.join(rechtsgrundlagen_benennung_collection) or None
                 )
                 schlagwort_collection = get_german_vocabulary(item.theme) + [
                     entry.value for entry in item.keyword
@@ -738,8 +725,8 @@ def transform_resources(
                         entityType=item.entityType,
                     ),
                 )
-            result_resoures_by_primary_source[primary_source] = datenkompass_resources
-        result_resoures_by_primary_source_by_unit[unit] = (
-            result_resoures_by_primary_source
+            result_resources_by_primary_source[primary_source] = datenkompass_resources
+        result_resources_by_primary_source_by_unit[unit] = (
+            result_resources_by_primary_source
         )
-    return result_resoures_by_primary_source_by_unit
+    return result_resources_by_primary_source_by_unit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "faker>=40",
     "mex-artificial>=3,<4",
     "mex-common>=3,<3.2",
+    "mex-model>=5,<6",
     "networkx>=3,<4",
     "numpy>=2,<3",
     "openpyxl>=3,<4",

--- a/tests/datenkompass/test_transform.py
+++ b/tests/datenkompass/test_transform.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from mex.common.types import Text, Theme
+from mex.common.types import Frequency, License, Text, Theme
 from mex.extractors.datenkompass.models.item import DatenkompassActivity
 from mex.extractors.datenkompass.models.mapping import (
     DatenkompassMapping,
@@ -140,8 +140,22 @@ def test_get_title(mocked_merged_activities: list[MergedActivity]) -> None:
 
 
 def test_get_german_vocabulary() -> None:
-    result = get_german_vocabulary([Theme["INFECTIOUS_DISEASES_AND_EPIDEMIOLOGY"]])
-    assert result == ["Infektionskrankheiten und -epidemiologie"]
+    result = get_german_vocabulary(
+        [
+            Theme["INFECTIOUS_DISEASES_AND_EPIDEMIOLOGY"],
+            Frequency["IRREGULAR"],
+            License["CREATIVE_COMMONS_ATTRIBUTION_INTERNATIONAL"],
+        ]
+    )
+    assert result == [
+        "Infektionskrankheiten und -epidemiologie",
+        "unregelmäßig",
+        "Creative Commons Namensnennung 4.0 International",
+    ]
+
+
+def test_get_german_vocabulary_none() -> None:
+    assert get_german_vocabulary(None) == []
 
 
 def test_get_datenbank(
@@ -307,9 +321,7 @@ def test_handle_setval_none_raises_error() -> None:
     ],
     ids=["filter for length", "last word just fits", "all filtered out", "empty input"],
 )
-def test_filter_schlagworte(
-    input_value: list[str | None], expected_output: str
-) -> None:
+def test_filter_schlagworte(input_value: list[str], expected_output: str) -> None:
     result = filter_schlagworte(
         input_value,
         "||",

--- a/uv.lock
+++ b/uv.lock
@@ -670,7 +670,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/a7/6ab1d4f9cd548d15ab90da29947f2076100130bb179b0bde59f795a459e3/greenlet-3.5.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7e8afa5eac028f8140ceafe5ceec66e6aa127ddcb21452d2a564dcd2900b5f22", size = 295410, upload-time = "2026-07-22T11:40:35.747Z" },
     { url = "https://files.pythonhosted.org/packages/cd/7a/422f63b4715cbc0b24385305407adf38b48f6bb68b3e6b04090e994d0f5a/greenlet-3.5.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73b37afe369021423ea53dd3123e04bffa7e93ac64429b9f50835b2e4fcae7cf", size = 661286, upload-time = "2026-07-22T12:26:43.8Z" },
     { url = "https://files.pythonhosted.org/packages/d0/31/5a1cac663bf5582190c5a714ef81364f03cde232227f39748f8ae4c11da5/greenlet-3.5.4-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ef964f56dfcb6f9bbef2a190d9126795eac408716aeae47b5e7c73c32aafca9", size = 673517, upload-time = "2026-07-22T12:29:04.815Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/bf/250c2921c7b585dde12f5239e313ca2dcbc464d161ecca36e4e6ef21762d/greenlet-3.5.4-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cef589bc65fae02d10bca2ac341191c5b33acc2967892ebf4fcbd10eabb7a74c", size = 677968, upload-time = "2026-07-22T12:43:46.788Z" },
     { url = "https://files.pythonhosted.org/packages/15/4a/2a82a1e3f8aaca020853ac8d12211280ca2b231aa08ea39f636f1060c319/greenlet-3.5.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c53ff01a5c53a40f2c16820ebc56d7c61a77f5fbe009dadd96292d5682f80f8", size = 670917, upload-time = "2026-07-22T11:51:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/18/40/10bfcf6513558d82f7b95dd728001c63bd388259fe27d3e30ae01f103430/greenlet-3.5.4-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:dfc41ae893d9ceaf22c824f2153a88b30651b20e8758c2cd9ac143f23640563c", size = 480643, upload-time = "2026-07-22T12:39:54.149Z" },
     { url = "https://files.pythonhosted.org/packages/68/b0/e379a152b17bfdfa95795af4049e37c0fd1b4d81f020d426db104ed07c77/greenlet-3.5.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecca4d80d55a01ad6b23b33262662956149fbb7b2c6be2910f1705921958cbf3", size = 1628478, upload-time = "2026-07-22T12:25:06.678Z" },
     { url = "https://files.pythonhosted.org/packages/5e/43/bffdfa64f7317f954c5c1230b5dd5922676ce198689a68c1ac1ed4b1b1a5/greenlet-3.5.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ffbc533e0eaf8e80d8471411646ab88fe58f641d508c0b02b24494479f4d9ec", size = 1692021, upload-time = "2026-07-22T11:51:17.008Z" },
     { url = "https://files.pythonhosted.org/packages/d0/11/f799f9637e2c6e9b0b716015e339040598b058cf7654dfc0d67468b177ed/greenlet-3.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:305f69e6c4523d7f6979ed001cff4e5853c063e5da04880296603aa0227e544c", size = 248031, upload-time = "2026-07-22T11:40:11.007Z" },
@@ -678,7 +680,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/69/35c62ed49c320cb4d98e14698ccca5467d3bfe683984172be9cb564d9ce3/greenlet-3.5.4-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:41ddab54e4b238f4a6c323f39b4e59e176affd5a94d461a9fb7583dac74240a3", size = 305571, upload-time = "2026-07-22T11:40:31.659Z" },
     { url = "https://files.pythonhosted.org/packages/5b/6c/64d60216b3640dcb0b62d913dd9e0d80030c09115bb2e4ba70c95d10ca45/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3dabe3e2809013052c68bdf0b7fa5f5f2859c43a80803131ad61af9cabd7867", size = 672568, upload-time = "2026-07-22T12:26:45.298Z" },
     { url = "https://files.pythonhosted.org/packages/5c/de/ba3ab0a96292e53039530333b0d2ae18d9e508f3a325cd7bf15f8172944c/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:27d3f00718634d4520a3a150154ac5da36f257869d41321953375b90bfbbc72c", size = 680076, upload-time = "2026-07-22T12:29:06.125Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/db/24a10af12bf8e639cec46c38b9ce1a282543ba42ff4fb0b31a970f1ab603/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39169a11d87a6a263afda3e9a27d1df16d0f919d40a4837cc73986c9884c0dd8", size = 681690, upload-time = "2026-07-22T12:43:48.109Z" },
     { url = "https://files.pythonhosted.org/packages/a5/be/aeada79083c6f1c15f45d77a332f9c441af263ee298e3eb17522cd337d22/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbd60b5763c6543c1827e48faaf14ea9bfbad245f52b1a4d76a2a2d8884c6c66", size = 676733, upload-time = "2026-07-22T11:51:16.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/60/44a2eca7b9fd71ae0fae7ff184da1cd3169d176652b97aa1cffcbb0ef961/greenlet-3.5.4-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:bd3d1145f603b2db19feb9078c2e6855eb7c67e15580c010ed815cee519b86fd", size = 510263, upload-time = "2026-07-22T12:39:55.678Z" },
     { url = "https://files.pythonhosted.org/packages/e9/10/2392fc3a98948652ef5fd1e7275c04f861dd13f74b78a2b4309f4ee4d090/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f00f910f0e7b35416c63b23ad78b769aeccfc1775f712b43c4ee525624a2eef7", size = 1637327, upload-time = "2026-07-22T12:25:07.879Z" },
     { url = "https://files.pythonhosted.org/packages/55/c6/e7237a3dfa1f205ed0d9ea1e46d70bd2811b32d516266399fb59d28ab90a/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:91c26423753b92caf41ab3f98fd547d7374d4d9fc2d85be041886c1579d9255e", size = 1697493, upload-time = "2026-07-22T11:51:19.214Z" },
     { url = "https://files.pythonhosted.org/packages/55/e3/4ba8154ba2a3d43729e499f72471b4b5c993f3826d3e24da81d5f06d6572/greenlet-3.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:ee032b91fd8ec29ec6c4cea2b8c561b178435134bd0752c7334b94e9c736c132", size = 251637, upload-time = "2026-07-22T11:40:37.44Z" },
@@ -1058,6 +1062,7 @@ dependencies = [
     { name = "faker" },
     { name = "mex-artificial" },
     { name = "mex-common" },
+    { name = "mex-model" },
     { name = "networkx" },
     { name = "numpy" },
     { name = "openpyxl" },
@@ -1100,6 +1105,7 @@ requires-dist = [
     { name = "faker", specifier = ">=40" },
     { name = "mex-artificial", specifier = ">=3,<4" },
     { name = "mex-common", specifier = ">=3,<3.2" },
+    { name = "mex-model", specifier = ">=5,<6" },
     { name = "networkx", specifier = ">=3,<4" },
     { name = "numpy", specifier = ">=2,<3" },
     { name = "openpyxl", specifier = ">=3,<4" },
@@ -1357,7 +1363,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
### PR Context
- we want to have static enums in mex-common ( which would not have a concept property anymore, so let's discontinue its use preemptively )

### Changes

- stop using `Vocabulary.__concepts__` in datencompass for fw-compat with static enums